### PR TITLE
docs: fix brand/Overview links to the site root

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -139,10 +139,10 @@
 <body>
   <div class="layout">
     <aside class="sidebar">
-      <a class="brand" href="{{ "/" | relURL }}">file<span>class</span></a>
+      <a class="brand" href="{{ .Site.Home.RelPermalink }}">file<span>class</span></a>
       <nav>
         {{ $current := . }}
-        <a href="{{ "/" | relURL }}"{{ if .IsHome }} class="active"{{ end }}>Overview</a>
+        <a href="{{ .Site.Home.RelPermalink }}"{{ if .IsHome }} class="active"{{ end }}>Overview</a>
         {{ range .Site.Menus.main }}
           <a href="{{ .URL | relURL }}"{{ if $current.IsMenuCurrent "main" . }} class="active"{{ end }}>{{ .Name }}</a>
         {{ end }}


### PR DESCRIPTION
`"/" | relURL` resolved to the domain root (mdelobelle.github.io), bypassing the /fileclass/ Pages path prefix. Use .Site.Home.RelPermalink so the brand and Overview links point at /fileclass/.