### PR TITLE
fix: label sync via gh label create --force

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -26,21 +26,13 @@ jobs:
       - name: Upsert labels from manifest
         run: |
           set -euo pipefail
-          # yq + jq are pre-installed on ubuntu-latest. yq converts YAML→JSON,
-          # jq emits one compact object per label.
+          # yq + jq + gh are pre-installed on ubuntu-latest. yq converts YAML→JSON,
+          # jq emits one compact object per label. `gh label create --force`
+          # creates the label or updates it if it already exists (handles name
+          # encoding correctly, unlike a hand-rolled GET/POST/PATCH).
           yq -o=json '.' .github/labels.yml | jq -c '.[]' | while IFS= read -r label; do
             name=$(jq -r '.name' <<<"$label")
             color=$(jq -r '.color' <<<"$label")
             desc=$(jq -r '.description // ""' <<<"$label")
-            enc=$(jq -rn --arg n "$name" '$n | @uri')   # URL-encode (e.g. "area:views")
-
-            if gh api "repos/$REPO/labels/$enc" >/dev/null 2>&1; then
-              gh api -X PATCH "repos/$REPO/labels/$enc" \
-                -f new_name="$name" -f color="$color" -f description="$desc" >/dev/null
-              echo "updated  $name"
-            else
-              gh api -X POST "repos/$REPO/labels" \
-                -f name="$name" -f color="$color" -f description="$desc" >/dev/null
-              echo "created  $name"
-            fi
+            gh label create "$name" --color "$color" --description "$desc" --force -R "$REPO"
           done


### PR DESCRIPTION
Replaces the hand-rolled GET/POST/PATCH upsert (422'd on names with a colon like area:views) with `gh label create --force`. Verified locally on all 19 labels.