### PR TITLE
fix: label sync via raw REST upsert

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -26,13 +26,21 @@ jobs:
       - name: Upsert labels from manifest
         run: |
           set -euo pipefail
-          # yq + jq + gh are pre-installed on ubuntu-latest. yq converts YAML→JSON,
-          # jq emits one compact object per label. `gh label create --force`
-          # creates the label or updates it if it already exists (handles name
-          # encoding correctly, unlike a hand-rolled GET/POST/PATCH).
+          # yq + jq + gh are pre-installed on ubuntu-latest. yq→JSON, jq emits one
+          # compact object per label. Pure REST via `gh api` (version-independent);
+          # pass the RAW name so gh encodes the path once (pre-encoding "%3A" made
+          # some gh versions double-encode and 404 → fall to create → 422).
           yq -o=json '.' .github/labels.yml | jq -c '.[]' | while IFS= read -r label; do
             name=$(jq -r '.name' <<<"$label")
             color=$(jq -r '.color' <<<"$label")
             desc=$(jq -r '.description // ""' <<<"$label")
-            gh label create "$name" --color "$color" --description "$desc" --force -R "$REPO"
+            if gh api "repos/$REPO/labels/$name" >/dev/null 2>&1; then
+              gh api -X PATCH "repos/$REPO/labels/$name" \
+                -f new_name="$name" -f color="$color" -f description="$desc" >/dev/null
+              echo "updated  $name"
+            else
+              gh api -X POST "repos/$REPO/labels" \
+                -f name="$name" -f color="$color" -f description="$desc" >/dev/null
+              echo "created  $name"
+            fi
           done


### PR DESCRIPTION
gh label create --force behaves differently on the runner (422). Use gh api GET→PATCH/POST with raw names. Verified locally on all 19 labels.