### PR TITLE
docs: lead with a concrete example (README + docs intro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Fileclass
 
-**Schemas, typed fields & data quality for your Obsidian vault — powered by the
-core Bases plugin.**
+**Give your notes typed, validated properties with guided input — define
+reusable note types, like a schema for your frontmatter.**
 
-Fileclass adds typed, validated, per-note-type property schemas
-("fileClasses") to your notes: guided input for every field, nested objects,
-data-quality checks, and generated Bases views — all **frontmatter-only**, with
-**no Dataview dependency**.
+You define reusable **note types** (called *fileClasses*), each with a fixed set
+of typed fields. For example, a **Book** type where `author` must be a link to a
+Person note, `status` is one of *Reading* / *Read* / *Abandoned*, and `rating`
+is a number from 1 to 5. Every note of that type then gets **guided input** for
+those fields (dropdowns, date pickers, link autocomplete), and Fileclass flags
+any note where a field is missing or has the wrong type.
+
+In short: a **schema and input forms for your frontmatter**. You define the
+fields and fill them in; the core **Bases** plugin queries and displays them. If
+you have used Notion databases or Metadata Menu, it is that idea — but
+**frontmatter-only**, with **no Dataview dependency**.
 
 📖 **Documentation: https://mdelobelle.github.io/fileclass/**
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,14 +4,28 @@ title: "Fileclass"
 
 # Fileclass
 
-**Fileclass** is the schema and data-quality layer for Obsidian vaults: typed,
-validated, per-note-type property schemas ("fileClasses") with guided input and
-nested objects — using the **core Bases plugin** as the query and view engine.
+**Fileclass** gives your notes **typed, validated properties** — and helps you
+fill them in correctly.
+
+You define reusable **note types** (called *fileClasses*), each with a fixed set
+of typed fields. For example, a **Book** type where:
+
+- `author` must be a link to a Person note,
+- `status` is one of *Reading* / *Read* / *Abandoned*,
+- `rating` is a number from 1 to 5.
+
+Every note of that type then gets **guided input** for those fields — dropdowns,
+date pickers, link autocomplete — and Fileclass flags any note where a field is
+missing or has the wrong type. In short, it's a **schema and input forms for your
+frontmatter**: you define the fields and fill them in; the core **Bases** plugin
+queries and displays them.
+
+If you have used Notion databases or Metadata Menu, it is that idea — but
+**frontmatter-only**, with **no Dataview dependency**.
 
 It is the successor of [Metadata Menu](https://github.com/mdelobelle/metadatamenu)
 (same author). Metadata Menu goes into maintenance mode; if you rely on Dataview
-inline fields (`key:: value`), stay there. Fileclass is **frontmatter-only** and
-has **no Dataview dependency**.
+inline fields (`key:: value`), stay there.
 
 ## Documentation
 

--- a/docs/content/positioning.md
+++ b/docs/content/positioning.md
@@ -3,6 +3,11 @@ title: "Positioning"
 weight: 10
 ---
 
+> **New here?** In one line: Fileclass lets you define *note types* with typed,
+> validated properties and guided input — a schema and input forms for your
+> frontmatter. See [What is Fileclass?](../) for a concrete example, then come
+> back here for how it compares to what you already use.
+
 Fileclass sits deliberately between three things Obsidian users already know.
 Understanding the boundaries is the fastest way to know whether it is for you.
 


### PR DESCRIPTION
Early Reddit feedback (the most-upvoted comments) reported that the repo/store description and the docs didn't convey what the plugin actually does — everything opened on abstract terms (*schema / typed fields / data quality*) that assume prior knowledge of Metadata Menu, Bases, or databases.

This PR leads with a concrete example instead:

- **README** — first paragraph (shown as the **community store description**) now opens on a concrete "Book" note type + what the user gets (guided input, validation).
- **docs home (`_index.md`)** — same concrete intro replaces the abstract opener.
- **positioning page** — adds a one-line plain-language recap linking back to the home, before the comparison tables.

The GitHub repo "About" description was also updated (outside this PR, via the repo settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)