### PR TITLE
chore(demo): onboarding-video tooling — 3-act scenario over CDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ data.json
 docs/public/
 docs/resources/
 docs/.hugo_build.lock
+
+# Demo/onboarding tooling
+demo/node_modules/
+demo/demo-vault/

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,66 @@
+# Fileclass onboarding-video tooling
+
+Full-auto: seed a demo vault, drive Obsidian over CDP, record the screen.
+Self-contained (its own `package.json`); not part of the plugin build.
+
+## Prerequisites
+
+- The plugin built once (from the repo root): `npm run build`.
+- `ffmpeg` (for recording): `brew install ffmpeg`.
+- Deps here: `cd demo && npm install`.
+
+## 1. Seed a demo vault
+
+```bash
+node seed.mjs --vault ./demo-vault
+```
+
+Creates a fresh vault with the plugin installed + enabled, `classFilesPath =
+Classes/`, a ready **Book** fileClass, and a few plain notes in `Library/`.
+
+## 2. Launch Obsidian on it with remote debugging
+
+```bash
+open -na Obsidian --args --remote-debugging-port=9222 \
+  "obsidian://open?path=$(pwd)/demo-vault"
+```
+
+Then, once open: make sure the core **Bases** plugin is enabled, size the window
+for the recording, and (optional) bump zoom with `Cmd +` for legibility.
+
+## 3. Record + drive
+
+Start the screen capture, then run the scenario. Two options:
+
+**ffmpeg (region capture, macOS avfoundation)** — list devices first:
+
+```bash
+ffmpeg -f avfoundation -list_devices true -i ""   # find your screen index
+# capture screen index 1 at 30fps into out.mp4 (Ctrl+C to stop):
+ffmpeg -f avfoundation -framerate 30 -i "1:none" -pix_fmt yuv420p demo.mp4
+```
+
+In another terminal, play the scenario:
+
+```bash
+node record.mjs
+```
+
+Stop ffmpeg when the scenario ends, then trim/add voice-over in any editor.
+
+**OBS** (if you prefer a GUI / webcam / live overlays): start recording in OBS,
+run `node record.mjs`, stop OBS. (Optionally automate start/stop via
+`obs-websocket`.)
+
+## Files
+
+- `seed.mjs` — (re)creates the demo vault.
+- `lib/driver.mjs` — CDP connection + fake cursor + step captions + helpers.
+- `record.mjs` — the scenario (see `scenario.md`).
+- `scenario.md` — storyboard + tuning notes.
+
+## Re-running for a new release
+
+Re-`npm run build` the plugin, re-run `seed.mjs` (it wipes and recreates the
+vault), relaunch Obsidian, and replay `record.mjs`. The run is deterministic, so
+the video is reproducible.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,13 +1,15 @@
 # Fileclass onboarding-video tooling
 
-Full-auto: seed a demo vault, drive Obsidian over CDP, record the screen.
-Self-contained (its own `package.json`); not part of the plugin build.
+Seed a demo vault, drive Obsidian over CDP, record the screen. The driver types,
+sets values, and detects results; **you do the mouse clicks** (see the handoff
+model below), so the pointer moves naturally on camera. Self-contained (its own
+`package.json`); not part of the plugin build.
 
 ## Prerequisites
 
 - The plugin built once (from the repo root): `npm run build`.
-- `ffmpeg` (for recording): `brew install ffmpeg`.
 - Deps here: `cd demo && npm install`.
+- A screen recorder — QuickTime is easiest (`ffmpeg` optional, see step 3).
 
 ## 1. Seed a demo vault
 
@@ -16,8 +18,9 @@ node seed.mjs                       # defaults to ~/fileclass-demo-vault
 # or: node seed.mjs --vault /some/path/outside/any/vault
 ```
 
-Creates a fresh vault (plugin installed + enabled, `classFilesPath = Classes/`,
-a ready **Book** fileClass, plain notes in `Library/`).
+Creates a fresh vault with **only** the plugin installed + enabled. Everything
+else — the `Classes/` folder, the `classFilesPath` setting, every fileClass and
+note — is created live, on camera, by `record.mjs`.
 
 > **Important:** the vault must live **outside** any existing vault — a vault
 > nested inside another can't be opened. That's why the default is in your home
@@ -55,8 +58,20 @@ File → New Screen Recording → pick the Obsidian window/region → Record. Th
 the scenario, and stop QuickTime when it ends:
 
 ```bash
-node record.mjs
+node record.mjs        # the whole story (acts 1 → 3)
+node record.mjs 1      # act 1 only (install + configure)
+node record.mjs 2      # act 2 only (define Author + author notes)
+node record.mjs 3      # act 3 only (base table + linked Book; needs act 2 first)
 ```
+
+### You drive the clicks (handoff model)
+The driver never clicks. When the bottom caption turns **purple and ends with
+`…`**, it's your turn: do the named click — a button, a pencil ✎, a command in
+the palette, a right-click menu item, or an option in a list. The driver watches
+the DOM and resumes automatically once your click takes effect, so you set the
+pace of the mouse. (The right-click menu opens in a separate window the debug
+port can't reach, so it must be manual anyway.) There's no fake cursor — add a
+pointer in post if you want one.
 
 **ffmpeg (scriptable, macOS avfoundation)** — for a fully headless capture:
 
@@ -76,10 +91,12 @@ Trim / add voice-over afterwards in any editor.
 
 ## Files
 
-- `seed.mjs` — (re)creates the demo vault.
-- `lib/driver.mjs` — CDP connection + fake cursor + step captions + helpers.
-- `record.mjs` — the scenario (see `scenario.md`).
-- `scenario.md` — storyboard + tuning notes.
+- `seed.mjs` — (re)creates the demo vault (plugin only; guards against nuking
+  real data).
+- `lib/driver.mjs` — CDP connection, step captions, purple click-handoffs, and
+  DOM detectors.
+- `record.mjs` — the scenario, in three steps (see `scenario.md`).
+- `scenario.md` — storyboard + how the handoff model works.
 
 ## Re-running for a new release
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -12,21 +12,37 @@ Self-contained (its own `package.json`); not part of the plugin build.
 ## 1. Seed a demo vault
 
 ```bash
-node seed.mjs --vault ./demo-vault
+node seed.mjs                       # defaults to ~/fileclass-demo-vault
+# or: node seed.mjs --vault /some/path/outside/any/vault
 ```
 
-Creates a fresh vault with the plugin installed + enabled, `classFilesPath =
-Classes/`, a ready **Book** fileClass, and a few plain notes in `Library/`.
+Creates a fresh vault (plugin installed + enabled, `classFilesPath = Classes/`,
+a ready **Book** fileClass, plain notes in `Library/`).
 
-## 2. Launch Obsidian on it with remote debugging
+> **Important:** the vault must live **outside** any existing vault — a vault
+> nested inside another can't be opened. That's why the default is in your home
+> folder, not under the plugin.
 
-```bash
-open -na Obsidian --args --remote-debugging-port=9222 \
-  "obsidian://open?path=$(pwd)/demo-vault"
-```
+## 2. Open the vault once, then relaunch with remote debugging
 
-Then, once open: make sure the core **Bases** plugin is enabled, size the window
-for the recording, and (optional) bump zoom with `Cmd +` for legibility.
+Obsidian can't open an arbitrary folder as a vault from a URI or `open -a`, so
+register it once:
+
+1. In Obsidian: **Open another vault → Open folder as vault** → pick the seeded
+   folder (e.g. `~/fileclass-demo-vault`).
+2. **Turn off Restricted mode** (trust the vault) so the **Fileclass** and core
+   **Bases** plugins load. Confirm Bases is enabled.
+3. **Quit Obsidian completely.**
+4. Relaunch with the debug port — it reopens the last vault (this one):
+
+   ```bash
+   open -na Obsidian --args --remote-debugging-port=9222
+   ```
+
+   If it opens a different vault, just switch to the demo vault in the picker —
+   the debug port stays active on the same process.
+
+Then size the window for recording and (optional) bump zoom with `Cmd +`.
 
 ## 3. Record + drive
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -46,27 +46,33 @@ Then size the window for recording and (optional) bump zoom with `Cmd +`.
 
 ## 3. Record + drive
 
-Start the screen capture, then run the scenario. Two options:
+The driving (`record.mjs`) is **independent of the capture** — record however you
+like, then play the scenario. `record.mjs` waits a couple of seconds on start so
+you can hit Record first.
 
-**ffmpeg (region capture, macOS avfoundation)** — list devices first:
-
-```bash
-ffmpeg -f avfoundation -list_devices true -i ""   # find your screen index
-# capture screen index 1 at 30fps into out.mp4 (Ctrl+C to stop):
-ffmpeg -f avfoundation -framerate 30 -i "1:none" -pix_fmt yuv420p demo.mp4
-```
-
-In another terminal, play the scenario:
+**QuickTime (simplest, manual)** — no setup:
+File → New Screen Recording → pick the Obsidian window/region → Record. Then run
+the scenario, and stop QuickTime when it ends:
 
 ```bash
 node record.mjs
 ```
 
-Stop ffmpeg when the scenario ends, then trim/add voice-over in any editor.
+**ffmpeg (scriptable, macOS avfoundation)** — for a fully headless capture:
 
-**OBS** (if you prefer a GUI / webcam / live overlays): start recording in OBS,
-run `node record.mjs`, stop OBS. (Optionally automate start/stop via
-`obs-websocket`.)
+```bash
+ffmpeg -f avfoundation -list_devices true -i ""   # find your screen index
+ffmpeg -f avfoundation -framerate 30 -i "1:none" -pix_fmt yuv420p demo.mp4
+```
+
+> ffmpeg needs the **Screen Recording** permission for your terminal app
+> (System Settings → Privacy & Security → Screen Recording → enable iTerm/Terminal,
+> then restart it). If that's a hassle, just use QuickTime.
+
+**OBS** (GUI / webcam / live overlays): start recording, run `node record.mjs`,
+stop. (Start/stop can be automated via `obs-websocket`.)
+
+Trim / add voice-over afterwards in any editor.
 
 ## Files
 

--- a/demo/lib/driver.mjs
+++ b/demo/lib/driver.mjs
@@ -1,0 +1,154 @@
+/*
+ * Puppeteer-over-CDP driver for the Obsidian demo recording. Connects to an
+ * Obsidian launched with --remote-debugging-port, injects a visible fake cursor
+ * and a step-label overlay (the OS cursor doesn't move when driven over CDP),
+ * and exposes small, deliberately-paced helpers.
+ */
+import puppeteer from "puppeteer-core";
+
+const PORT = process.env.OBSIDIAN_CDP_PORT || "9222";
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export async function connectObsidian() {
+	const browser = await puppeteer.connect({
+		browserURL: `http://127.0.0.1:${PORT}`,
+		defaultViewport: null,
+	});
+	const pages = await browser.pages();
+	const page = pages.find((p) => p.url().startsWith("app://obsidian.md")) ?? pages[0];
+	if (!page) throw new Error("No Obsidian renderer page found on the debug port.");
+	await injectOverlay(page);
+	return new Driver(browser, page);
+}
+
+async function injectOverlay(page) {
+	await page.evaluate(() => {
+		if (document.getElementById("fc-demo-cursor")) return;
+		const cursor = document.createElement("div");
+		cursor.id = "fc-demo-cursor";
+		const label = document.createElement("div");
+		label.id = "fc-demo-label";
+		const style = document.createElement("style");
+		style.textContent = `
+			#fc-demo-cursor{position:fixed;z-index:99999;width:22px;height:22px;margin:-11px 0 0 -11px;
+				border-radius:50%;background:rgba(120,82,238,.35);border:2px solid #7852ee;
+				pointer-events:none;transition:transform .05s linear;left:0;top:0}
+			#fc-demo-cursor.click{animation:fcPing .4s ease-out}
+			@keyframes fcPing{0%{box-shadow:0 0 0 0 rgba(120,82,238,.5)}100%{box-shadow:0 0 0 22px rgba(120,82,238,0)}}
+			#fc-demo-label{position:fixed;z-index:99999;left:50%;bottom:38px;transform:translateX(-50%);
+				max-width:70vw;padding:10px 18px;border-radius:10px;background:rgba(20,20,28,.9);color:#fff;
+				font-size:20px;font-weight:600;pointer-events:none;opacity:0;transition:opacity .25s}
+			#fc-demo-label.show{opacity:1}`;
+		document.head.appendChild(style);
+		document.body.appendChild(cursor);
+		document.body.appendChild(label);
+	});
+}
+
+class Driver {
+	constructor(browser, page) {
+		this.browser = browser;
+		this.page = page;
+		this.x = 200;
+		this.y = 200;
+	}
+
+	async close() {
+		this.browser.disconnect();
+	}
+
+	/** Sets the caption at the bottom of the screen (empty string hides it). */
+	async step(text) {
+		await this.page.evaluate((t) => {
+			const el = document.getElementById("fc-demo-label");
+			if (!el) return;
+			el.textContent = t;
+			el.classList.toggle("show", !!t);
+		}, text);
+	}
+
+	async #moveCursor(x, y) {
+		await this.page.evaluate(
+			(x, y) => {
+				const c = document.getElementById("fc-demo-cursor");
+				if (c) c.style.transform = `translate(${x}px,${y}px)`;
+			},
+			x,
+			y
+		);
+	}
+
+	/** Glides the (fake + CDP) cursor to viewport coordinates, easing over steps. */
+	async moveTo(x, y, steps = 24) {
+		const { x: sx, y: sy } = this;
+		for (let i = 1; i <= steps; i++) {
+			const t = i / steps;
+			const ease = t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+			const cx = sx + (x - sx) * ease;
+			const cy = sy + (y - sy) * ease;
+			await this.#moveCursor(cx, cy);
+			await this.page.mouse.move(cx, cy);
+			await sleep(12);
+		}
+		this.x = x;
+		this.y = y;
+	}
+
+	async clickAt(x, y) {
+		await this.moveTo(x, y);
+		await this.page.evaluate(() => document.getElementById("fc-demo-cursor")?.classList.add("click"));
+		await this.page.mouse.click(x, y);
+		await sleep(120);
+		await this.page.evaluate(() => document.getElementById("fc-demo-cursor")?.classList.remove("click"));
+		await sleep(250);
+	}
+
+	/** Waits for `selector` (optionally the Nth / one whose text matches) and clicks its center. */
+	async click(selector, { nth = 0, hasText } = {}) {
+		await this.page.waitForSelector(selector, { visible: true, timeout: 8000 });
+		const box = await this.page.evaluate(
+			(sel, nth, hasText) => {
+				let els = [...document.querySelectorAll(sel)];
+				if (hasText) els = els.filter((e) => e.textContent?.trim() === hasText);
+				const el = els[nth];
+				if (!el) return null;
+				el.scrollIntoView({ block: "center" });
+				const r = el.getBoundingClientRect();
+				return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+			},
+			selector,
+			nth,
+			hasText
+		);
+		if (!box) throw new Error(`No element for ${selector}${hasText ? ` ("${hasText}")` : ""}`);
+		await this.clickAt(box.x, box.y);
+	}
+
+	async type(text, delay = 55) {
+		await this.page.keyboard.type(text, { delay });
+		await sleep(300);
+	}
+
+	async press(...keys) {
+		for (const k of keys) await this.page.keyboard.down(k);
+		for (const k of [...keys].reverse()) await this.page.keyboard.up(k);
+		await sleep(300);
+	}
+
+	/** Runs a plugin/app command by id (silent, reliable). */
+	async command(id) {
+		await this.page.evaluate((id) => window.app.commands.executeCommandById(id), id);
+		await sleep(600);
+	}
+
+	/** Opens the command palette and runs `query` visibly (Cmd/Ctrl+P → type → Enter). */
+	async palette(query) {
+		const mod = process.platform === "darwin" ? "Meta" : "Control";
+		await this.press(mod, "p");
+		await sleep(400);
+		await this.type(query, 45);
+		await sleep(500);
+		await this.press("Enter");
+	}
+}

--- a/demo/lib/driver.mjs
+++ b/demo/lib/driver.mjs
@@ -1,8 +1,13 @@
 /*
  * Puppeteer-over-CDP driver for the Obsidian demo recording. Connects to an
- * Obsidian launched with --remote-debugging-port, injects a visible fake cursor
- * and a step-label overlay (the OS cursor doesn't move when driven over CDP),
- * and exposes small, deliberately-paced helpers.
+ * Obsidian launched with --remote-debugging-port and injects a step-label
+ * overlay at the bottom of the screen.
+ *
+ * The driver never clicks: mouse clicks are handed off to the operator (purple
+ * caption ending in `…`) so they control the pointer's timing, and the driver
+ * resumes automatically by watching the DOM (`clickHandoff`/`awaitInPage`). It
+ * still drives the keyboard (typing, Enter/Esc) and sets <select>/date values
+ * directly. The visible pointer is added later in the screen capture.
  */
 import puppeteer from "puppeteer-core";
 
@@ -15,41 +20,42 @@ export async function connectObsidian() {
 		browserURL: `http://127.0.0.1:${PORT}`,
 		defaultViewport: null,
 	});
-	const pages = await browser.pages();
-	const page = pages.find((p) => p.url().startsWith("app://obsidian.md")) ?? pages[0];
-	if (!page) throw new Error("No Obsidian renderer page found on the debug port.");
-	await injectOverlay(page);
-	return new Driver(browser, page);
+	// The main window is the page exposing window.app (settings may live in a
+	// separate window whose URL is about:blank, so match by app, not by URL).
+	let appPage = null;
+	for (const p of await browser.pages()) {
+		if (await p.evaluate(() => !!window.app).catch(() => false)) {
+			appPage = p;
+			break;
+		}
+	}
+	if (!appPage) throw new Error("No Obsidian renderer page (window.app) on the debug port.");
+	await injectOverlay(appPage);
+	return new Driver(browser, appPage);
 }
 
 async function injectOverlay(page) {
 	await page.evaluate(() => {
-		if (document.getElementById("fc-demo-cursor")) return;
-		const cursor = document.createElement("div");
-		cursor.id = "fc-demo-cursor";
+		if (document.getElementById("fc-demo-label")) return;
 		const label = document.createElement("div");
 		label.id = "fc-demo-label";
 		const style = document.createElement("style");
 		style.textContent = `
-			#fc-demo-cursor{position:fixed;z-index:99999;width:22px;height:22px;margin:-11px 0 0 -11px;
-				border-radius:50%;background:rgba(120,82,238,.35);border:2px solid #7852ee;
-				pointer-events:none;transition:transform .05s linear;left:0;top:0}
-			#fc-demo-cursor.click{animation:fcPing .4s ease-out}
-			@keyframes fcPing{0%{box-shadow:0 0 0 0 rgba(120,82,238,.5)}100%{box-shadow:0 0 0 22px rgba(120,82,238,0)}}
 			#fc-demo-label{position:fixed;z-index:99999;left:50%;bottom:38px;transform:translateX(-50%);
 				max-width:70vw;padding:10px 18px;border-radius:10px;background:rgba(20,20,28,.9);color:#fff;
 				font-size:20px;font-weight:600;pointer-events:none;opacity:0;transition:opacity .25s}
-			#fc-demo-label.show{opacity:1}`;
+			#fc-demo-label.show{opacity:1}
+			#fc-demo-label.handoff{background:rgba(120,82,238,.95);box-shadow:0 0 0 3px rgba(120,82,238,.35)}`;
 		document.head.appendChild(style);
-		document.body.appendChild(cursor);
 		document.body.appendChild(label);
 	});
 }
 
 class Driver {
-	constructor(browser, page) {
+	constructor(browser, appPage) {
 		this.browser = browser;
-		this.page = page;
+		this.appPage = appPage; // the window.app page (for commands/eval)
+		this.page = appPage; // the active page for UI interactions
 		this.x = 200;
 		this.y = 200;
 	}
@@ -58,87 +64,233 @@ class Driver {
 		this.browser.disconnect();
 	}
 
+	/**
+	 * Switches UI interactions to whichever window's document contains `selector`.
+	 * This Obsidian build opens settings, the plugin browser, etc. as SEPARATE
+	 * windows, so we follow the DOM rather than assume a single page.
+	 */
+	async useWindowWith(selector, { timeout = 8000 } = {}) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			for (const p of await this.browser.pages()) {
+				const has = await p
+					.evaluate((s) => document.querySelector(s) != null, selector)
+					.catch(() => false);
+				if (has) {
+					await injectOverlay(p);
+					this.page = p;
+					this.x = this.y = 120;
+					return;
+				}
+			}
+			await sleep(200);
+		}
+		throw new Error(`No window contains "${selector}"`);
+	}
+
+	/** Convenience: switch to the settings window. */
+	async useSettingsWindow(opts) {
+		return this.useWindowWith(".mod-settings", opts);
+	}
+
+	/** Switches UI interactions back to the main app window. */
+	useMainWindow() {
+		this.page = this.appPage;
+		this.x = this.y = 200;
+	}
+
 	/** Sets the caption at the bottom of the screen (empty string hides it). */
 	async step(text) {
+		this._handoffActive = false;
 		await this.page.evaluate((t) => {
 			const el = document.getElementById("fc-demo-label");
 			if (!el) return;
 			el.textContent = t;
+			el.classList.remove("handoff");
 			el.classList.toggle("show", !!t);
 		}, text);
 	}
 
-	async #moveCursor(x, y) {
-		await this.page.evaluate(
-			(x, y) => {
-				const c = document.getElementById("fc-demo-cursor");
-				if (c) c.style.transform = `translate(${x}px,${y}px)`;
-			},
-			x,
-			y
-		);
+	/**
+	 * Shows a "your turn" caption (accent style + trailing `…`) for actions the
+	 * CDP driver can't perform — notably the file context menu, which this
+	 * Obsidian build renders in a separate window unreachable over the debug
+	 * port. Pair with `awaitInPage()` to detect when you've done the click and
+	 * resume automatically. Caption is set on the app (main) window so it stays
+	 * visible while you interact with the popped-out menu.
+	 */
+	async handoff(text) {
+		this._handoffActive = true;
+		await this.appPage.evaluate((t) => {
+			const el = document.getElementById("fc-demo-label");
+			if (!el) return;
+			el.textContent = `${t}   …`;
+			el.classList.add("show", "handoff");
+		}, text);
 	}
 
-	/** Glides the (fake + CDP) cursor to viewport coordinates, easing over steps. */
-	async moveTo(x, y, steps = 24) {
-		const { x: sx, y: sy } = this;
-		for (let i = 1; i <= steps; i++) {
-			const t = i / steps;
-			const ease = t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
-			const cx = sx + (x - sx) * ease;
-			const cy = sy + (y - sy) * ease;
-			await this.#moveCursor(cx, cy);
-			await this.page.mouse.move(cx, cy);
-			await sleep(12);
+	/** Hides the caption (used to clear a handoff the instant it's satisfied). */
+	async clearCaption() {
+		this._handoffActive = false;
+		await this.appPage.evaluate(() => {
+			const el = document.getElementById("fc-demo-label");
+			if (el) el.classList.remove("show", "handoff");
+		});
+	}
+
+	/**
+	 * Polls a predicate in the main window until it returns truthy (or times
+	 * out). Used to detect the result of a manual click — a modal appearing, or
+	 * frontmatter gaining fields — so the scenario can continue hands-free. When
+	 * a handoff caption is showing, it's cleared the instant the click lands (so
+	 * the purple prompt disappears as soon as you act).
+	 */
+	async awaitInPage(fn, { timeout = 180000, poll = 250, args = [] } = {}) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const ok = await this.appPage.evaluate(fn, ...args).catch(() => false);
+			if (ok) {
+				if (this._handoffActive) await this.clearCaption();
+				return;
+			}
+			await sleep(poll);
 		}
-		this.x = x;
-		this.y = y;
+		throw new Error("Timed out waiting for the manual click (no DOM change detected).");
 	}
 
-	async clickAt(x, y) {
-		await this.moveTo(x, y);
-		await this.page.evaluate(() => document.getElementById("fc-demo-cursor")?.classList.add("click"));
-		await this.page.mouse.click(x, y);
-		await sleep(120);
-		await this.page.evaluate(() => document.getElementById("fc-demo-cursor")?.classList.remove("click"));
-		await sleep(250);
+	/**
+	 * Sets the caption and waits for your click to take effect. Pairs a purple
+	 * `…` handoff with a DOM predicate — the one primitive the scenario uses for
+	 * every mouse click (buttons, pencils, palette rows, menu items, options).
+	 */
+	async clickHandoff(caption, detect, opts = {}) {
+		await this.handoff(caption);
+		await this.awaitInPage(detect, opts);
 	}
 
-	/** Waits for `selector` (optionally the Nth / one whose text matches) and clicks its center. */
-	async click(selector, { nth = 0, hasText } = {}) {
-		await this.page.waitForSelector(selector, { visible: true, timeout: 8000 });
-		const box = await this.page.evaluate(
-			(sel, nth, hasText) => {
-				let els = [...document.querySelectorAll(sel)];
-				if (hasText) els = els.filter((e) => e.textContent?.trim() === hasText);
-				const el = els[nth];
-				if (!el) return null;
+	/** Focuses an input in the active window (no mouse) and types into it. */
+	async fill(selector, text, { modal = false, clear = true, nth = 0 } = {}) {
+		await this.page.waitForSelector(selector, { visible: true, timeout: 8000 }).catch(() => {});
+		const found = await this.page.evaluate(
+			(sel, nth, modal) => {
+				const modals = [...document.querySelectorAll(".modal")];
+				const root = modal && modals.length ? modals[modals.length - 1] : document;
+				const el = [...root.querySelectorAll(sel)].at(nth); // negative nth = from end
+				if (!el) return false;
 				el.scrollIntoView({ block: "center" });
-				const r = el.getBoundingClientRect();
-				return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+				el.focus();
+				return true;
 			},
 			selector,
 			nth,
-			hasText
+			modal
 		);
-		if (!box) throw new Error(`No element for ${selector}${hasText ? ` ("${hasText}")` : ""}`);
-		await this.clickAt(box.x, box.y);
+		if (!found) throw new Error(`No input for ${selector}`);
+		if (clear) await this.press(process.platform === "darwin" ? "Meta" : "Control", "a");
+		await this.type(text);
 	}
 
-	async type(text, delay = 55) {
-		await this.page.keyboard.type(text, { delay });
+	/** Focuses the input in the modal's setting row whose name equals `label`. */
+	async fillSetting(label, text, { clear = true } = {}) {
+		const found = await this.page.evaluate((label) => {
+			const modals = [...document.querySelectorAll(".modal")];
+			const root = modals[modals.length - 1] ?? document;
+			const item = [...root.querySelectorAll(".setting-item")].find(
+				(s) => s.querySelector(".setting-item-name")?.textContent?.trim() === label
+			);
+			const el = item?.querySelector("input[type='text'], input:not([type])");
+			if (!el) return false;
+			el.scrollIntoView({ block: "center" });
+			el.focus();
+			return true;
+		}, label);
+		if (!found) throw new Error(`No setting input for "${label}"`);
+		if (clear) await this.press(process.platform === "darwin" ? "Meta" : "Control", "a");
+		await this.type(text);
+		await this.appPage.evaluate(() => document.activeElement?.blur()); // close any suggest popover
+		await sleep(150);
+	}
+
+	/** Sets a <select>'s value and fires change (reliable vs. option clicking). */
+	async select(value, { selector = "select", modal = true } = {}) {
+		await this.page.evaluate(
+			(sel, value, modal) => {
+				const modals = [...document.querySelectorAll(".modal")];
+				const root = modal && modals.length ? modals[modals.length - 1] : document;
+				const el = root.querySelector(sel);
+				if (!el) return;
+				el.value = value;
+				el.dispatchEvent(new Event("change", { bubbles: true }));
+			},
+			selector,
+			value,
+			modal
+		);
+		await sleep(120);
+	}
+
+	/** Sets an input's value directly and fires input+change (dates, etc.). */
+	async setValue(selector, value, { modal = true } = {}) {
+		await this.page.evaluate(
+			(sel, value, modal) => {
+				const modals = [...document.querySelectorAll(".modal")];
+				const root = modal && modals.length ? modals[modals.length - 1] : document;
+				const el = root.querySelector(sel);
+				if (!el) return;
+				el.value = value;
+				el.dispatchEvent(new Event("input", { bubbles: true }));
+				el.dispatchEvent(new Event("change", { bubbles: true }));
+			},
+			selector,
+			value,
+			modal
+		);
 		await sleep(300);
+	}
+
+	/** Runs arbitrary code in the Obsidian renderer (setup shortcuts). App window. */
+	async eval(fn, ...args) {
+		return this.appPage.evaluate(fn, ...args);
+	}
+
+	/** { name, path } of the vault currently open in the connected Obsidian. */
+	async vault() {
+		return this.appPage.evaluate(() => ({
+			name: window.app.vault.getName(),
+			path: window.app.vault.adapter?.getBasePath?.() ?? "",
+		}));
+	}
+
+	/**
+	 * Safety gate: refuse to drive unless the connected vault matches `expected`
+	 * (name or path substring). Prevents scripted actions hitting a real vault.
+	 */
+	async assertVault(expected) {
+		const v = await this.vault();
+		const ok = v.name === expected || v.path.includes(expected);
+		console.log(`Connected vault: "${v.name}" (${v.path})`);
+		if (!ok) {
+			throw new Error(
+				`Refusing to run: connected vault "${v.name}" does not match "${expected}". ` +
+					`Open the demo vault in the debugged Obsidian (or set FILECLASS_DEMO_VAULT).`
+			);
+		}
+	}
+
+	async type(text, delay = 28) {
+		await this.page.keyboard.type(text, { delay });
+		await sleep(90);
 	}
 
 	async press(...keys) {
 		for (const k of keys) await this.page.keyboard.down(k);
 		for (const k of [...keys].reverse()) await this.page.keyboard.up(k);
-		await sleep(300);
+		await sleep(110);
 	}
 
-	/** Runs a plugin/app command by id (silent, reliable). */
+	/** Runs a plugin/app command by id (silent, reliable). Always on the app window. */
 	async command(id) {
-		await this.page.evaluate((id) => window.app.commands.executeCommandById(id), id);
+		await this.appPage.evaluate((id) => window.app.commands.executeCommandById(id), id);
 		await sleep(600);
 	}
 
@@ -150,5 +302,14 @@ class Driver {
 		await this.type(query, 45);
 		await sleep(500);
 		await this.press("Enter");
+	}
+
+	/** Opens the command palette and types `query` (leaving the list shown to click). */
+	async openPalette(query) {
+		const mod = process.platform === "darwin" ? "Meta" : "Control";
+		await this.press(mod, "p");
+		await sleep(500);
+		await this.type(query, 50);
+		await sleep(700);
 	}
 }

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,0 +1,1081 @@
+{
+  "name": "fileclass-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fileclass-demo",
+      "devDependencies": {
+        "puppeteer-core": "^23.0.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ip-address": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fileclass-demo",
+  "private": true,
+  "type": "module",
+  "description": "Scripted onboarding-video tooling for Fileclass (seeds a demo vault + drives Obsidian over CDP).",
+  "scripts": {
+    "seed": "node seed.mjs",
+    "record": "node record.mjs"
+  },
+  "devDependencies": {
+    "puppeteer-core": "^23.0.0"
+  }
+}

--- a/demo/record.mjs
+++ b/demo/record.mjs
@@ -1,94 +1,500 @@
 /*
- * Drives Obsidian through the onboarding scenario over CDP. Connect first:
- * launch Obsidian on the seeded demo vault with --remote-debugging-port=9222
- * (see README), then `node record.mjs`. Screen-record separately (ffmpeg/OBS).
+ * Drives Obsidian through the onboarding scenario over CDP.
  *
- * The scenario mostly triggers plugin *commands* (reliable) and clicks the few
- * visual highlights (pickers) by button text. Selectors/timings for the modal
- * steps may need a light tuning pass against your Obsidian version — they're
- * grouped in scenario steps below with generous pauses.
+ *   node record.mjs        # run all steps
+ *   node record.mjs 1      # run only step 1 (install + configure)
+ *   node record.mjs 2      # run only step 2 (create a fileClass + author notes)
+ *   node record.mjs 3      # run only step 3 (base table + linked Book class)
+ *
+ * Launch Obsidian on the seeded vault (plugin pre-installed) with
+ * --remote-debugging-port=9222, start your screen recording, then run this.
+ * Steps are independent so you can iterate/tune one at a time. The in-modal
+ * clicks (schema editor, pickers) are the parts most likely to need a light
+ * selector/timing tuning pass.
+ *
+ * MANUAL CLICKS: the driver never clicks — it types, sets <select>/date values,
+ * and detects results, but every MOUSE click is yours so you control the
+ * pointer's timing. When the caption turns purple and ends with "…", do the
+ * named click (a button, a pencil ✎, a palette row, a right-click menu item, a
+ * list option); the driver watches the DOM and resumes once it takes effect.
+ * (The right-click menu in particular renders in a separate window the debug
+ * port can't reach, so it could never be driven anyway.) Add a visible pointer
+ * in post if you like — there's no fake cursor in the run.
  */
 import { connectObsidian, sleep } from "./lib/driver.mjs";
 
-const BOOK = "Dune"; // the Library note we structure on camera
-const beat = (ms = 900) => sleep(ms);
-
+const beat = (ms = 450) => sleep(ms);
+// Safety: only ever drive the demo vault (override with FILECLASS_DEMO_VAULT).
+const EXPECT_VAULT = process.env.FILECLASS_DEMO_VAULT || "fileclass-demo-vault";
 const d = await connectObsidian();
 
-try {
-	// Lead-in: gives you a moment after hitting Record (QuickTime) before it starts.
-	await d.step("");
-	await beat(2500);
+const AUTHORS = [
+	// Two entry points to the same three actions (add fileClass, insert missing
+	// fields, manage note fields) — so the video teaches both:
+	//   author 1 → the command palette (driver opens it; you click the row),
+	//   author 2 → the file's right-click menu (you right-click, then click).
+	// `blurb` is the on-screen story line shown when the note is created.
+	{ name: "Frank Herbert", birthdate: "1920-10-08", country: "UK", mode: "palette",
+		blurb: "Our first author — we'll tag Frank from the command palette" },
+	{ name: "Arnaldur Indriðason", birthdate: "1961-01-28", country: "Iceland", mode: "menu",
+		blurb: "A second author — Arnaldur, this time from the right-click menu" },
+];
+const COUNTRIES = ["USA", "UK", "Iceland"];
 
-	// 1. Open a plain note — "here's an unstructured note".
-	await d.step("A plain note — no schema yet");
-	await d.page.evaluate((name) => window.app.workspace.openLinkText(name, "", false), BOOK);
+// --- Step 1: install (pre-staged) + create Classes/ + configure it -----------
+// The live store install opens several separate windows in this build — too
+// jumpy for a clean recording — so the plugin is pre-installed (seed.mjs) and
+// this shows a caption. The folder + setting ARE shown on camera.
+async function step1() {
+	await d.step("Fileclass turns plain notes into typed, structured data — no code");
 	await beat(1600);
 
-	// 2. Bind it to the Book fileClass.
-	await d.step("Give it a type: the Book fileClass");
-	await d.command("fileclass:add-class-to-note");
-	await beat();
-	// The class picker (a suggester) is open — pick "Book".
-	await d.type("Book", 60);
-	await beat();
-	await d.press("Enter");
-	await beat(1400);
+	// Create the folder that will hold fileClass notes (appears in the explorer),
+	// and expand it so the Author fileClass is visible inside it once created.
+	await d.step("First, a home for your classes — the Classes/ folder");
+	await d.eval(() => window.app.vault.createFolder("Classes").catch(() => { }));
+	await beat(1000);
+	await d.eval(() => {
+		const view = window.app.workspace.getLeavesOfType("file-explorer")[0]?.view;
+		view?.fileItems?.["Classes"]?.setCollapsed?.(false);
+	});
+	await beat(1000);
 
-	// 3. Insert the schema's fields into the note.
-	await d.step("Insert the fileClass fields");
-	await d.command("fileclass:insert-missing-fields-in-current-file");
-	await beat(1600);
-
-	// 4. Fill values through the guided inputs (the visual highlights).
-	await d.step("Fill values with guided, typed inputs");
-	await d.command("fileclass:manage-note-fields");
-	await beat(1200);
-
-	// status → Select dropdown (each row exposes a pencil; click "status"'s)
-	await clickRowAction("status");
-	await beat();
-	await d.click(".suggestion-item", { hasText: "Reading" }).catch(() => d.press("Enter"));
-	await beat(1200);
-
-	// cover → Color picker (circular swatches)
-	await clickRowAction("cover");
-	await beat();
-	await d.click(".fileclass-color-circle", { nth: 4 }); // a palette color
-	await beat(1200);
-
-	// icon → Icon grid
-	await clickRowAction("icon");
-	await beat();
-	await d.type("book", 70);
-	await beat();
-	await d.click(".fileclass-icon-cell", { nth: 0 });
-	await beat(1200);
-
-	// 5. Generate a base and open the table.
-	await d.step("Generate a Bases table for this fileClass");
-	await d.command("fileclass:create-base");
-	await beat(1800);
-	await d.command("fileclass:open-base");
-	await beat(2500);
-
-	await d.step("Typed, validated, frontmatter-only — try Fileclass");
-	await beat(2500);
+	// Point Fileclass at that folder (Settings → Fileclass → Class files folder).
+	await d.step("Tell Fileclass where they live, and you're set up");
+	await d.eval(() => {
+		window.app.setting.open();
+		window.app.setting.openTabById("fileclass");
+	});
+	await d.useSettingsWindow();
+	await beat(1000);
+	await d.fill(".vertical-tab-content input[type='text']", "Classes", { nth: 0 });
+	await d.press("Escape"); // dismiss the folder autocomplete
+	await beat(550);
+	await d.useMainWindow();
+	await d.eval(() => window.app.setting.close());
+	await beat(2000);
 	await d.step("");
-} finally {
-	await d.close();
 }
 
-/** Clicks the edit (pencil) action on the note-fields row whose name matches. */
-async function clickRowAction(fieldName) {
-	const box = await d.page.evaluate((name) => {
-		const rows = [...document.querySelectorAll(".modal .fileclass-field-row")];
-		const row = rows.find((r) => r.querySelector(".setting-item-name")?.textContent?.includes(name));
-		const btn = row?.querySelector(".setting-item-control .clickable-icon");
-		if (!btn) return null;
-		btn.scrollIntoView({ block: "center" });
-		const r = btn.getBoundingClientRect();
-		return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
-	}, fieldName);
-	if (box) await d.clickAt(box.x, box.y);
+// --- Step 2: create an Author fileClass, then two author notes ---------------
+// Every mouse click is yours (purple caption + `…`); the driver types, sets
+// <select>/date values, and detects each click's effect in the DOM.
+async function step2() {
+	await resetStep2Artifacts(); // idempotent: a re-run starts from a clean slate
+
+	// Create the fileClass from the command palette (you click the command);
+	// then the PromptModal — name typed, Enter submits.
+	await d.step("Every structure starts with a type. Let's define an Author");
+	await d.openPalette("Fileclass"); // driver opens + filters (keyboard)
+	await d.clickHandoff(
+		"In the palette, run “Create a class”",
+		() => !!document.querySelector(".modal input[type='text']")
+	);
+	await beat(300);
+	await d.type("Author");
+	await d.press("Enter");
+	await d.awaitInPage(() =>
+		[...document.querySelectorAll(".modal button")].some((b) => b.textContent.includes("Add field"))
+	);
+	await beat(400);
+
+	// Field: birthdate (Date)
+	await d.step("An author has a birthday — give it a typed Date field");
+	await addField("birthdate", "Date", "Add the first field. Click “Add field”");
+	await saveFieldDef();
+	await beat(400);
+
+	// Field: country (Select) with a few values
+	await d.step("…and a home country — a Select with a fixed set of values");
+	await addField("country", "Select", "Add another field. Click “Add field”");
+	for (const c of COUNTRIES) {
+		const before = await d.eval(() => {
+			const m = [...document.querySelectorAll(".modal")].pop();
+			return m ? m.querySelectorAll("input[type='text']").length : 0;
+		});
+		await d.clickHandoff(
+			"List a country. Click “Add value”",
+			(n) => {
+				const m = [...document.querySelectorAll(".modal")].pop();
+				return !!m && m.querySelectorAll("input[type='text']").length > n;
+			},
+			{ args: [before] }
+		);
+		await beat(150);
+		await d.fill(".modal input[type='text']", c, { modal: true, nth: -1, clear: false });
+	}
+	await beat(250);
+	await saveFieldDef();
+	await beat(400);
+	await d.press("Escape"); // close the schema editor (keyboard)
+	await beat(400);
+	await d.step("");
+
+	// Two author notes, filled through the note-fields modal.
+	for (const a of AUTHORS) {
+		await fillAuthor(a);
+	}
+
+	await d.step("Two authors, fully typed — and we never wrote a line of code");
+	await beat(1600);
+	await d.step("");
+}
+
+// --- Step 3: a Bases table for Author, a live edit, and a linked Book ---------
+// Builds on step 2's artifacts (the Author fileClass + author notes). Shows the
+// fileClass → base table, editing a field reflected in it, and a File field on
+// a new Book fileClass whose candidates come from the Author table.
+async function step3() {
+	const ready = await d.eval(() => {
+		const idx = window.app.plugins.plugins.fileclass.index;
+		return idx.fileClassNames.includes("Author") && !!window.app.vault.getAbstractFileByPath("Frank Herbert.md");
+	});
+	if (!ready) throw new Error("Step 3 needs step 2's artifacts — run `node record.mjs 2` first.");
+	await resetStep3Artifacts();
+
+	// 3.1 — Create a Bases table for Author, from the fileClass's right-click menu.
+	await d.step("Structure you can see — turn the class into a Bases table");
+	await revealPath("Classes/Author.md");
+	await d.handoff("Right-click “Author” (in Classes/) → Create a base for this fileClass");
+	await d.awaitInPage(() =>
+		[...document.querySelectorAll(".modal")].some((m) =>
+			[...m.querySelectorAll("button")].some((b) => b.textContent.includes("Create / sync"))
+		)
+	);
+	await beat(500);
+	await clickToCloseModal("Keep the defaults — click “Create / sync”");
+	await d.awaitInPage(() => {
+		const idx = window.app.plugins.plugins.fileclass.index;
+		const bf = idx.getFileClass("Author")?.options?.baseFile;
+		return !!bf && !!window.app.vault.getAbstractFileByPath(bf);
+	});
+	// Open the table so the next edit is visible on camera.
+	await d.eval(async () => {
+		const idx = window.app.plugins.plugins.fileclass.index;
+		const bf = idx.getFileClass("Author")?.options?.baseFile;
+		const f = bf && window.app.vault.getAbstractFileByPath(bf);
+		if (f) await window.app.workspace.getLeaf(true).openFile(f);
+	});
+	await d.step("Your authors as a live table — one row per note");
+	await beat(1800);
+
+	// 3.2 — Edit Frank Herbert's country by clicking its cell in the table.
+	// Cells in the fileclass-table view are editable: a click opens the field's
+	// value editor and the row updates in place.
+	await d.step("And it's editable — change a value right in the table");
+	const prevCountry = await d.eval(
+		() => window.app.metadataCache.getFileCache(window.app.vault.getAbstractFileByPath("Frank Herbert.md"))?.frontmatter?.country ?? null
+	);
+	await d.clickHandoff(
+		"Click Frank Herbert's country cell",
+		() => document.querySelector(".prompt input")?.placeholder === "Set country"
+	);
+	await d.clickHandoff(
+		"Pick a different country — the row updates instantly",
+		(prev) => {
+			const v = window.app.metadataCache.getFileCache(window.app.vault.getAbstractFileByPath("Frank Herbert.md"))?.frontmatter?.country ?? null;
+			return v !== null && v !== prev;
+		},
+		{ args: [prevCountry] }
+	);
+	await beat(1500);
+
+	// 3.3 — Create a Book fileClass with an "author" File field sourced from the table.
+	await d.step("Classes can link to each other. Let's add a Book");
+	await d.openPalette("Fileclass");
+	await d.clickHandoff("In the palette, run “Create a class”", () => !!document.querySelector(".modal input[type='text']"));
+	await beat(300);
+	await d.type("Book");
+	await d.press("Enter");
+	await d.awaitInPage(() =>
+		[...document.querySelectorAll(".modal button")].some((b) => b.textContent.includes("Add field"))
+	);
+	await beat(400);
+
+	await d.step("Give Book an “author” field that points at real authors");
+	await d.clickHandoff("Link Book to Author. Click “Add field”", () => {
+		const m = [...document.querySelectorAll(".modal")].pop();
+		return !!(m && m.querySelector("select"));
+	});
+	await beat(300);
+	await d.fill(".modal input[type='text']", "author", { modal: true, nth: 0 });
+	await beat(200);
+	await d.clickHandoff(
+		"Select the “File” type",
+		(t) => {
+			const m = [...document.querySelectorAll(".modal")].pop();
+			return !!m && [...m.querySelectorAll("select")].some((s) => s.value === t);
+		},
+		{ args: ["File"] }
+	);
+	await beat(400);
+	// Point the field at the Author base (blank View = the first/managed view).
+	const baseFile = await d.eval(() => window.app.plugins.plugins.fileclass.index.getFileClass("Author")?.options?.baseFile ?? "");
+	await d.step("Its choices come straight from the Author table");
+	await d.fillSetting("Base file", baseFile);
+	await beat(300);
+	await saveFieldDef();
+	await beat(300);
+	await d.press("Escape"); // close the schema editor
+	await beat(400);
+	await d.step("");
+
+	// 3.4 — A Book note "Dune": add the class, insert fields, pick the author.
+	await d.step("A new book joins the library: Dune");
+	await d.eval(async () => {
+		const f = await window.app.vault.create("Dune.md", "");
+		await window.app.workspace.getLeaf(true).openFile(f);
+	});
+	await beat(500);
+	await revealInExplorer("Dune");
+
+	await d.openPalette("Fileclass");
+	await d.handoff("In the palette, run “Add a class to this note”");
+	await d.awaitInPage(() => document.querySelector(".prompt input")?.placeholder === "Select a fileClass to add");
+	await d.clickHandoff("Tag it as a Book — choose “Book”", () => {
+		const pl = window.app.plugins.plugins.fileclass;
+		const f = window.app.vault.getAbstractFileByPath("Dune.md");
+		const v = (window.app.metadataCache.getFileCache(f)?.frontmatter ?? {})[pl.settings.fileClassAlias];
+		return Array.isArray(v) ? v.includes("Book") : v === "Book";
+	});
+
+	await d.openPalette("Fileclass");
+	await d.handoff("In the palette, run “Insert missing fields”");
+	await d.awaitInPage(() => {
+		const f = window.app.vault.getAbstractFileByPath("Dune.md");
+		return "author" in (window.app.metadataCache.getFileCache(f)?.frontmatter ?? {});
+	});
+
+	await d.openPalette("Fileclass");
+	await d.handoff("In the palette, run “Manage note fields”");
+	await d.awaitInPage(() =>
+		[...document.querySelectorAll(".modal")].some((m) => m.querySelector(".fileclass-field-row"))
+	);
+
+	await d.step("Now link its author — the choices are your Author notes");
+	await d.clickHandoff(
+		"Open the picker — click ✎ on “author”",
+		() => document.querySelector(".prompt input")?.placeholder === "Set author"
+	);
+	await d.clickHandoff("Choose the author — “Frank Herbert”", () => {
+		const f = window.app.vault.getAbstractFileByPath("Dune.md");
+		const v = (window.app.metadataCache.getFileCache(f)?.frontmatter ?? {}).author;
+		const s = Array.isArray(v) ? v.join(",") : v ?? "";
+		return String(s).includes("Frank Herbert");
+	});
+	await d.press("Escape"); // close the note-fields modal
+
+	await d.step("Dune, by Frank Herbert — a typed, linked library, all in frontmatter");
+	await beat(1800);
+	await d.step("");
+}
+
+/**
+ * Resets step 3's artifacts (Book fileClass, Dune, the Author base) and reverts
+ * Frank's country to USA, so a re-run is clean and the "Create a base" menu item
+ * (not "Modify base") shows again. Safe: guarded by assertVault; only named
+ * files touched.
+ */
+async function resetStep3Artifacts() {
+	await d.press("Escape");
+	await d.press("Escape");
+	await d.eval(async () => {
+		const app = window.app;
+		const idx = app.plugins.plugins.fileclass.index;
+		for (const p of ["Classes/Book.md", "Dune.md"]) {
+			const f = app.vault.getAbstractFileByPath(p);
+			if (f) await app.vault.delete(f, true);
+		}
+		const bf = idx.getFileClass("Author")?.options?.baseFile;
+		if (bf) {
+			const b = app.vault.getAbstractFileByPath(bf);
+			if (b) await app.vault.delete(b, true);
+		}
+		const author = app.vault.getAbstractFileByPath("Classes/Author.md");
+		if (author)
+			await app.fileManager.processFrontMatter(author, (fm) => {
+				delete fm.baseFile;
+				delete fm.baseView;
+			});
+		const frank = app.vault.getAbstractFileByPath("Frank Herbert.md");
+		if (frank) await app.fileManager.processFrontMatter(frank, (fm) => (fm.country = "USA"));
+	});
+	await beat(400);
+}
+
+async function fillAuthor({ name, birthdate, country, mode, blurb }) {
+	await d.step(blurb);
+	await d.eval(async (n) => {
+		const f = await window.app.vault.create(`${n}.md`, "");
+		await window.app.workspace.getLeaf(true).openFile(f);
+	}, name);
+	await beat(400);
+	await revealInExplorer(name); // put the right-click target on screen
+
+	// (1) Add the Author fileClass — palette (driver opens) or right-click menu.
+	await invokeAction(mode, "Add a class to this note", `Right-click “${name}” → Add fileClass`);
+	await d.awaitInPage(
+		() => document.querySelector(".prompt input")?.placeholder === "Select a fileClass to add"
+	);
+	await d.clickHandoff(
+		"Give the note its type — choose “Author”",
+		(p) => {
+			const pl = window.app.plugins.plugins.fileclass;
+			const f = window.app.vault.getAbstractFileByPath(p);
+			const v = (window.app.metadataCache.getFileCache(f)?.frontmatter ?? {})[pl.settings.fileClassAlias];
+			return Array.isArray(v) ? v.includes("Author") : v === "Author";
+		},
+		{ args: [`${name}.md`] }
+	);
+
+	// (2) Insert the schema's fields.
+	await invokeAction(mode, "Insert missing fields", `Right-click “${name}” → Insert missing fields`);
+	await d.awaitInPage(
+		(p) => {
+			const f = window.app.vault.getAbstractFileByPath(p);
+			const fm = window.app.metadataCache.getFileCache(f)?.frontmatter ?? {};
+			return "birthdate" in fm && "country" in fm;
+		},
+		{ args: [`${name}.md`] }
+	);
+
+	// (3) Open the note-fields modal.
+	await invokeAction(mode, "Manage note fields", `Right-click “${name}” → Manage note fields`);
+	await d.awaitInPage(() =>
+		[...document.querySelectorAll(".modal")].some((m) => m.querySelector(".fileclass-field-row"))
+	);
+
+	// Fill it (same for both authors).
+	await d.step(`Now give ${name} some values — guided, typed inputs`);
+
+	// birthdate → Date modal: you click ✎, I set the date, you click Save.
+	await d.clickHandoff("Set the birthday — click ✎ on “birthdate”", () =>
+		[...document.querySelectorAll(".modal")].some((m) => m.querySelector("input[type='date']"))
+	);
+	await d.setValue("input[type='date']", birthdate, { modal: true });
+	await beat(200);
+	// Detect the Date modal closing by modal count (the note-fields modal keeps
+	// an inline date input once the value is set, so "no date input" never holds).
+	await clickToCloseModal("Save the date. Click “Save”");
+
+	// country → Select suggester: you click ✎, then click the value.
+	await d.clickHandoff("Now the country — click ✎ on “country”", () => !!document.querySelector(".prompt input"));
+	await d.clickHandoff(
+		`Pick from the list — choose “${country}”`,
+		(p, c) => {
+			const f = window.app.vault.getAbstractFileByPath(p);
+			const v = (window.app.metadataCache.getFileCache(f)?.frontmatter ?? {}).country;
+			return Array.isArray(v) ? v.includes(c) : v === c;
+		},
+		{ args: [`${name}.md`, country] }
+	);
+
+	await d.press("Escape"); // close the note-fields modal (keyboard)
+	await d.step("");
+	await beat(400);
+}
+
+/** You click "Add field"; the driver types the name; then you pick the type. */
+async function addField(name, type, caption) {
+	await d.clickHandoff(caption, () => {
+		const m = [...document.querySelectorAll(".modal")].pop();
+		return !!(m && m.querySelector("select"));
+	});
+	await beat(300);
+	await d.fill(".modal input[type='text']", name, { modal: true, nth: 0 });
+	await beat(200);
+	// You open the type dropdown and choose the type; resume when it's set.
+	await d.clickHandoff(
+		`Give it a type — open the dropdown and choose “${type}”`,
+		(t) => {
+			const m = [...document.querySelectorAll(".modal")].pop();
+			return !!m && [...m.querySelectorAll("select")].some((s) => s.value === t);
+		},
+		{ args: [type] }
+	);
+	await beat(300);
+}
+
+/** Invokes a note action: via the palette (driver opens; you click) or the menu. */
+async function invokeAction(mode, paletteName, menuCaption) {
+	if (mode === "palette") {
+		await d.openPalette("Fileclass"); // driver opens + filters (keyboard)
+		await d.handoff(`In the palette, run “${paletteName}”`);
+	} else {
+		await d.handoff(menuCaption);
+	}
+}
+
+/** You click the field-def modal's "Save"; resumes once that modal has closed. */
+async function saveFieldDef() {
+	await clickToCloseModal("Save the field. Click “Save”");
+}
+
+/** Hands off a click that should close the top modal; resumes when it's gone. */
+async function clickToCloseModal(caption) {
+	const before = await d.eval(() => document.querySelectorAll(".modal").length);
+	await d.clickHandoff(caption, (n) => document.querySelectorAll(".modal").length < n, { args: [before] });
+}
+
+/**
+ * Deletes the artifacts step 2 creates (the Author fileClass note + the author
+ * notes), so a re-run starts clean. Without this, re-adding the existing
+ * `birthdate` field is rejected as a duplicate and the "Save" never closes.
+ * Safe: the runner has already asserted we're in the demo vault, and only these
+ * named files are removed.
+ */
+async function resetStep2Artifacts() {
+	await d.press("Escape"); // dismiss any modal/prompt left open by a prior run
+	await d.press("Escape");
+	const paths = ["Classes/Author.md", ...AUTHORS.map((a) => `${a.name}.md`)];
+	await d.eval(async (names) => {
+		for (const path of names) {
+			const f = window.app.vault.getAbstractFileByPath(path);
+			if (f) await window.app.vault.delete(f, true);
+		}
+	}, paths);
+	await beat(300);
+}
+
+/** Scrolls a note into view in the file explorer (right-click target). */
+async function revealInExplorer(name) {
+	await revealPath(`${name}.md`);
+}
+
+/** Expands ancestor folders and scrolls the path's item into view. */
+async function revealPath(path) {
+	await d.eval((p) => {
+		const view = window.app.workspace.getLeavesOfType("file-explorer")[0]?.view;
+		const parts = p.split("/");
+		let acc = "";
+		for (let i = 0; i < parts.length - 1; i++) {
+			acc = acc ? `${acc}/${parts[i]}` : parts[i];
+			view?.fileItems?.[acc]?.setCollapsed?.(false);
+		}
+		view?.fileItems?.[p]?.selfEl?.scrollIntoView({ block: "center" });
+	}, path);
+}
+
+// --- runner ------------------------------------------------------------------
+const steps = { 1: step1, 2: step2, 3: step3 };
+const which = process.argv[2];
+
+try {
+	await d.assertVault(EXPECT_VAULT); // abort if not the demo vault — protects real data
+	await d.step("");
+	await beat(2000); // lead-in after you hit Record
+	if (which) {
+		if (!steps[which]) throw new Error(`Unknown step "${which}" (use 1, 2 or 3)`);
+		await steps[which]();
+	} else {
+		await step1();
+		await step2();
+		await step3();
+	}
+} catch (err) {
+	console.error("Scenario failed:", err.message);
+	process.exitCode = 1;
+} finally {
+	await d.close();
 }

--- a/demo/record.mjs
+++ b/demo/record.mjs
@@ -1,0 +1,90 @@
+/*
+ * Drives Obsidian through the onboarding scenario over CDP. Connect first:
+ * launch Obsidian on the seeded demo vault with --remote-debugging-port=9222
+ * (see README), then `node record.mjs`. Screen-record separately (ffmpeg/OBS).
+ *
+ * The scenario mostly triggers plugin *commands* (reliable) and clicks the few
+ * visual highlights (pickers) by button text. Selectors/timings for the modal
+ * steps may need a light tuning pass against your Obsidian version — they're
+ * grouped in scenario steps below with generous pauses.
+ */
+import { connectObsidian, sleep } from "./lib/driver.mjs";
+
+const BOOK = "Dune"; // the Library note we structure on camera
+const beat = (ms = 900) => sleep(ms);
+
+const d = await connectObsidian();
+
+try {
+	// 1. Open a plain note — "here's an unstructured note".
+	await d.step("A plain note — no schema yet");
+	await d.page.evaluate((name) => window.app.workspace.openLinkText(name, "", false), BOOK);
+	await beat(1600);
+
+	// 2. Bind it to the Book fileClass.
+	await d.step("Give it a type: the Book fileClass");
+	await d.command("fileclass:add-class-to-note");
+	await beat();
+	// The class picker (a suggester) is open — pick "Book".
+	await d.type("Book", 60);
+	await beat();
+	await d.press("Enter");
+	await beat(1400);
+
+	// 3. Insert the schema's fields into the note.
+	await d.step("Insert the fileClass fields");
+	await d.command("fileclass:insert-missing-fields-in-current-file");
+	await beat(1600);
+
+	// 4. Fill values through the guided inputs (the visual highlights).
+	await d.step("Fill values with guided, typed inputs");
+	await d.command("fileclass:manage-note-fields");
+	await beat(1200);
+
+	// status → Select dropdown (each row exposes a pencil; click "status"'s)
+	await clickRowAction("status");
+	await beat();
+	await d.click(".suggestion-item", { hasText: "Reading" }).catch(() => d.press("Enter"));
+	await beat(1200);
+
+	// cover → Color picker (circular swatches)
+	await clickRowAction("cover");
+	await beat();
+	await d.click(".fileclass-color-circle", { nth: 4 }); // a palette color
+	await beat(1200);
+
+	// icon → Icon grid
+	await clickRowAction("icon");
+	await beat();
+	await d.type("book", 70);
+	await beat();
+	await d.click(".fileclass-icon-cell", { nth: 0 });
+	await beat(1200);
+
+	// 5. Generate a base and open the table.
+	await d.step("Generate a Bases table for this fileClass");
+	await d.command("fileclass:create-base");
+	await beat(1800);
+	await d.command("fileclass:open-base");
+	await beat(2500);
+
+	await d.step("Typed, validated, frontmatter-only — try Fileclass");
+	await beat(2500);
+	await d.step("");
+} finally {
+	await d.close();
+}
+
+/** Clicks the edit (pencil) action on the note-fields row whose name matches. */
+async function clickRowAction(fieldName) {
+	const box = await d.page.evaluate((name) => {
+		const rows = [...document.querySelectorAll(".modal .fileclass-field-row")];
+		const row = rows.find((r) => r.querySelector(".setting-item-name")?.textContent?.includes(name));
+		const btn = row?.querySelector(".setting-item-control .clickable-icon");
+		if (!btn) return null;
+		btn.scrollIntoView({ block: "center" });
+		const r = btn.getBoundingClientRect();
+		return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+	}, fieldName);
+	if (box) await d.clickAt(box.x, box.y);
+}

--- a/demo/record.mjs
+++ b/demo/record.mjs
@@ -16,6 +16,10 @@ const beat = (ms = 900) => sleep(ms);
 const d = await connectObsidian();
 
 try {
+	// Lead-in: gives you a moment after hitting Record (QuickTime) before it starts.
+	await d.step("");
+	await beat(2500);
+
 	// 1. Open a plain note — "here's an unstructured note".
 	await d.step("A plain note — no schema yet");
 	await d.page.evaluate((name) => window.app.workspace.openLinkText(name, "", false), BOOK);

--- a/demo/scenario.md
+++ b/demo/scenario.md
@@ -1,0 +1,24 @@
+# Onboarding video — storyboard
+
+Target length ~60–90 s. Voice-over/subtitles added in post.
+
+| # | On screen | Driven by | Caption |
+|---|-----------|-----------|---------|
+| 0 | Open `Dune` (a plain note) | `openLinkText` | "A plain note — no schema yet" |
+| 1 | Add class → pick **Book** | `add-class-to-note` + type "Book" | "Give it a type: the Book fileClass" |
+| 2 | Fields appear in Properties | `insert-missing-fields-in-current-file` | "Insert the fileClass fields" |
+| 3 | Note-fields modal opens | `manage-note-fields` | "Fill values with guided, typed inputs" |
+| 3a | **status** → dropdown (constrained) | pencil on status row | — |
+| 3b | **cover** → Color picker (circles) | pencil on cover row | — |
+| 3c | **icon** → Icon grid (search "book") | pencil on icon row | — |
+| 4 | Generate + open the Bases table | `create-base` → `open-base` | "Generate a Bases table for this fileClass" |
+| 5 | Table with swatch/glyph previews | — | "Typed, validated, frontmatter-only — try Fileclass" |
+
+## What's seeded vs shown live
+- **Seeded** (`seed.mjs`): the plugin (installed + enabled), `classFilesPath = Classes/`, a ready **Book** fileClass (status/rating/cover/icon/read), and three plain book notes in `Library/`.
+- **Shown live** (`record.mjs`): binding a note, inserting fields, filling values via the pretty pickers, and the generated table — the payoff, with the least fragile clicking.
+
+## Notes for tuning
+- The modal steps (3a–3c) click by row name / element index — adjust `nth`/text if your theme or Obsidian version shifts the DOM.
+- Increase the `beat()` pauses for a calmer pace; the fake cursor eases between points.
+- For a "build the schema live" variant, add steps around `edit-class-schema` before step 2 (more clicks, more fragile).

--- a/demo/scenario.md
+++ b/demo/scenario.md
@@ -1,24 +1,67 @@
 # Onboarding video — storyboard
 
-Target length ~60–90 s. Voice-over/subtitles added in post.
+Target length ~2–3 min. Voice-over/subtitles can be added in post, but the
+on-screen captions (`d.step(...)`) already tell the story.
 
-| # | On screen | Driven by | Caption |
-|---|-----------|-----------|---------|
-| 0 | Open `Dune` (a plain note) | `openLinkText` | "A plain note — no schema yet" |
-| 1 | Add class → pick **Book** | `add-class-to-note` + type "Book" | "Give it a type: the Book fileClass" |
-| 2 | Fields appear in Properties | `insert-missing-fields-in-current-file` | "Insert the fileClass fields" |
-| 3 | Note-fields modal opens | `manage-note-fields` | "Fill values with guided, typed inputs" |
-| 3a | **status** → dropdown (constrained) | pencil on status row | — |
-| 3b | **cover** → Color picker (circles) | pencil on cover row | — |
-| 3c | **icon** → Icon grid (search "book") | pencil on icon row | — |
-| 4 | Generate + open the Bases table | `create-base` → `open-base` | "Generate a Bases table for this fileClass" |
-| 5 | Table with swatch/glyph previews | — | "Typed, validated, frontmatter-only — try Fileclass" |
+## The story arc
 
-## What's seeded vs shown live
-- **Seeded** (`seed.mjs`): the plugin (installed + enabled), `classFilesPath = Classes/`, a ready **Book** fileClass (status/rating/cover/icon/read), and three plain book notes in `Library/`.
-- **Shown live** (`record.mjs`): binding a note, inserting fields, filling values via the pretty pickers, and the generated table — the payoff, with the least fragile clicking.
+**Act 1 — set the stage** (`step1`)
+| On screen | Caption |
+|-----------|---------|
+| Fileclass is installed (pre-staged) | "Fileclass turns plain notes into typed, structured data — no code" |
+| Create the `Classes/` folder | "First, a home for your classes — the Classes/ folder" |
+| Set `classFilesPath` in settings | "Tell Fileclass where they live, and you're set up" |
 
-## Notes for tuning
-- The modal steps (3a–3c) click by row name / element index — adjust `nth`/text if your theme or Obsidian version shifts the DOM.
-- Increase the `beat()` pauses for a calmer pace; the fake cursor eases between points.
-- For a "build the schema live" variant, add steps around `edit-class-schema` before step 2 (more clicks, more fragile).
+**Act 2 — define a type, then create real notes** (`step2`)
+| On screen | Caption |
+|-----------|---------|
+| Palette → Create a class → **Author** | "Every structure starts with a type. Let's define an Author" |
+| Add a **Date** field `birthdate` | "An author has a birthday — give it a typed Date field" |
+| Add a **Select** field `country` (values) | "…and a home country — a Select with a fixed set of values" |
+| Author **Frank Herbert** — via the command palette | "Our first author — we'll tag Frank from the command palette" |
+| Author **Arnaldur Indriðason** — via the right-click menu | "A second author — Arnaldur, this time from the right-click menu" |
+| Fill each note's fields (guided, typed inputs) | "Now give … some values — guided, typed inputs" |
+| — | "Two authors, fully typed — and we never wrote a line of code" |
+
+**Act 3 — see it, edit it, connect it** (`step3`, builds on step 2)
+| On screen | Caption |
+|-----------|---------|
+| Right-click the Author fileClass → create its base | "Structure you can see — turn the class into a Bases table" |
+| The generated table opens | "Your authors as a live table — one row per note" |
+| Edit Frank's country **in a table cell** | "And it's editable — change a value right in the table" |
+| Palette → Create a class → **Book** | "Classes can link to each other. Let's add a Book" |
+| Add an **author** field, type **File**, source = the Author base | "Its choices come straight from the Author table" |
+| New note **Dune**: add Book, insert fields | "A new book joins the library: Dune" |
+| Pick the author from the table's candidates | "Now link its author — the choices are your Author notes" |
+| — | "Dune, by Frank Herbert — a typed, linked library, all in frontmatter" |
+
+## How the driver works (manual-click model)
+The driver **never clicks** — it types text, sets `<select>`/date values, opens
+the palette, and watches the DOM. **Every mouse click is yours**, so you control
+the pointer's timing: when the caption turns **purple and ends with `…`**, do
+the named click (a button, a pencil ✎, a palette row, a right-click menu item, a
+list option). The driver detects the result and resumes on its own.
+
+Two reasons clicks are handed off:
+- The file **right-click menu** renders in a separate window the debug port
+  can't reach — it could never be driven anyway.
+- Manual clicks look natural on camera and let you pace the mouse.
+
+There's **no fake cursor** in the run — add a visible pointer in post if you want
+one.
+
+## Seeded vs shown live
+- **Seeded** (`seed.mjs`): only the plugin (installed + enabled). Nothing else —
+  the `Classes/` folder, the `classFilesPath` setting, and every fileClass and
+  note are created **on camera**.
+- **Shown live** (`record.mjs`): the whole arc above.
+
+## Running / tuning
+- `node record.mjs` runs everything; `node record.mjs 1|2|3` runs one act (step 3
+  needs step 2's artifacts — run it at least once first).
+- Each step is idempotent: it deletes its own artifacts up front, so re-runs
+  start clean.
+- Pace: adjust the `beat(...)` pauses (a small helper at the top of `record.mjs`).
+- Detectors key off the DOM (modal counts, placeholders, frontmatter) — robust
+  across themes; if a future Obsidian version renames things, adjust the
+  predicates in `record.mjs`.

--- a/demo/seed.mjs
+++ b/demo/seed.mjs
@@ -1,0 +1,125 @@
+/*
+ * Seeds a self-contained demo vault for the onboarding video.
+ *
+ *   node seed.mjs --vault ./demo-vault
+ *
+ * It (re)creates the vault from scratch: installs the built Fileclass plugin,
+ * enables it, sets its settings, and drops a few plain notes to structure live
+ * in the recording. The plugin build is taken from the parent folder (run
+ * `npm run build` in the plugin first). Bases is a core plugin — make sure it's
+ * enabled in the demo vault (it is by default on Obsidian 1.13+).
+ */
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(here, ".."); // the fileclass plugin repo root
+
+function arg(name, fallback) {
+	const i = process.argv.indexOf(`--${name}`);
+	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const vault = resolve(arg("vault", join(here, "demo-vault")));
+const dot = join(vault, ".obsidian");
+const pluginOut = join(dot, "plugins", "fileclass");
+
+console.log(`Seeding demo vault at ${vault}`);
+rmSync(vault, { recursive: true, force: true });
+mkdirSync(pluginOut, { recursive: true });
+
+// --- install the built plugin ------------------------------------------------
+for (const f of ["main.js", "manifest.json", "styles.css"]) {
+	const src = join(pluginDir, f);
+	if (!existsSync(src)) throw new Error(`Missing ${f} — run \`npm run build\` in the plugin first.`);
+	cpSync(src, join(pluginOut, f));
+}
+
+const write = (rel, data) =>
+	writeFileSync(join(vault, rel), typeof data === "string" ? data : JSON.stringify(data, null, 2));
+
+// --- Obsidian config ---------------------------------------------------------
+write(".obsidian/community-plugins.json", ["fileclass"]);
+// A clean, legible look for video. Adjust to taste.
+write(".obsidian/appearance.json", { baseFontSize: 18, theme: "obsidian" });
+write(".obsidian/app.json", { promptDelete: false });
+// Fileclass settings: fileClasses live in Classes/.
+write(".obsidian/plugins/fileclass/data.json", { classFilesPath: "Classes/" });
+
+// --- content -----------------------------------------------------------------
+mkdirSync(join(vault, "Classes"), { recursive: true });
+mkdirSync(join(vault, "Library"), { recursive: true });
+
+// A ready-made "Book" fileClass with visual field types (Select / Number /
+// Color / Icon / Date) — the recording binds a note to it and fills the values.
+write(
+	"Classes/Book.md",
+	`---
+icon: book
+mapWithTag: false
+fields:
+  - name: status
+    id: fcStatus
+    type: Select
+    path: ""
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Reading list
+        "2": Reading
+        "3": Read
+        "4": Abandoned
+  - name: rating
+    id: fcRating
+    type: Number
+    path: ""
+    options:
+      min: 0
+      max: 5
+  - name: cover
+    id: fcCover
+    type: Color
+    path: ""
+    options: {}
+  - name: icon
+    id: fcIcon
+    type: Icon
+    path: ""
+    options: {}
+  - name: read
+    id: fcRead
+    type: Date
+    path: ""
+    options: {}
+---
+
+The **Book** fileClass — status, rating, cover color, icon, read date.
+`
+);
+
+// A few book notes with plain frontmatter (no fileClass yet) — the live demo
+// gives them structure by creating a "Book" fileClass and binding them.
+const books = [
+	{ title: "The Left Hand of Darkness", author: "Ursula K. Le Guin", year: 1969 },
+	{ title: "Dune", author: "Frank Herbert", year: 1965 },
+	{ title: "Kindred", author: "Octavia E. Butler", year: 1979 },
+];
+for (const b of books) {
+	write(
+		`Library/${b.title}.md`,
+		`---\ntitle: ${b.title}\nauthor: ${b.author}\nyear: ${b.year}\n---\n\n# ${b.title}\n\nby ${b.author}\n`
+	);
+}
+
+// A short welcome note to open first in the recording.
+write(
+	"Welcome.md",
+	`# Fileclass — quick tour\n\nA schema for your frontmatter: typed, validated properties with guided input.\n\nWe'll create a **Book** fileClass, structure the notes in \`Library/\`, and generate a table.\n`
+);
+
+console.log("Done. Launch Obsidian on this vault with remote debugging, e.g.:");
+console.log(
+	`  open -na Obsidian --args --remote-debugging-port=9222 "obsidian://open?path=${encodeURIComponent(vault)}"`
+);
+console.log("Ensure the core Bases plugin is enabled, then run: node record.mjs");

--- a/demo/seed.mjs
+++ b/demo/seed.mjs
@@ -10,6 +10,7 @@
  * enabled in the demo vault (it is by default on Obsidian 1.13+).
  */
 import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,7 +22,8 @@ function arg(name, fallback) {
 	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
 }
 
-const vault = resolve(arg("vault", join(here, "demo-vault")));
+// Default OUTSIDE any vault — a vault nested inside another vault can't be opened.
+const vault = resolve(arg("vault", join(homedir(), "fileclass-demo-vault")));
 const dot = join(vault, ".obsidian");
 const pluginOut = join(dot, "plugins", "fileclass");
 
@@ -118,8 +120,11 @@ write(
 	`# Fileclass — quick tour\n\nA schema for your frontmatter: typed, validated properties with guided input.\n\nWe'll create a **Book** fileClass, structure the notes in \`Library/\`, and generate a table.\n`
 );
 
-console.log("Done. Launch Obsidian on this vault with remote debugging, e.g.:");
-console.log(
-	`  open -na Obsidian --args --remote-debugging-port=9222 "obsidian://open?path=${encodeURIComponent(vault)}"`
-);
-console.log("Ensure the core Bases plugin is enabled, then run: node record.mjs");
+console.log(`\nDone. Vault: ${vault}\n`);
+console.log("Next (see README.md):");
+console.log("  1. In Obsidian → Open another vault → Open folder as vault → pick the folder above (once).");
+console.log("  2. Turn off Restricted mode (trust) so the Fileclass + Bases plugins load.");
+console.log("  3. Quit Obsidian, then relaunch it with remote debugging:");
+console.log("       open -na Obsidian --args --remote-debugging-port=9222");
+console.log("     (it reopens the last vault = this one; if not, switch to it in the vault picker).");
+console.log("  4. node record.mjs");

--- a/demo/seed.mjs
+++ b/demo/seed.mjs
@@ -1,17 +1,18 @@
 /*
- * Seeds a self-contained demo vault for the onboarding video.
+ * Seeds a demo vault for the onboarding video with Fileclass PRE-INSTALLED and
+ * configured (classFilesPath = Classes/). Installing from the Community-plugins
+ * store on camera opens several separate windows in this Obsidian build — too
+ * fragile/jumpy for a clean recording — so the video shows a caption + a calm
+ * settings glance, and creates fileClasses/notes live (step 2).
  *
- *   node seed.mjs --vault ./demo-vault
+ *   node seed.mjs                       # ~/fileclass-demo-vault
+ *   node seed.mjs --vault /some/path    # elsewhere (outside any vault!)
  *
- * It (re)creates the vault from scratch: installs the built Fileclass plugin,
- * enables it, sets its settings, and drops a few plain notes to structure live
- * in the recording. The plugin build is taken from the parent folder (run
- * `npm run build` in the plugin first). Bases is a core plugin — make sure it's
- * enabled in the demo vault (it is by default on Obsidian 1.13+).
+ * Build the plugin first (repo root): npm run build.
  */
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -21,110 +22,53 @@ function arg(name, fallback) {
 	const i = process.argv.indexOf(`--${name}`);
 	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
 }
+function fail(msg) {
+	console.error(`Refusing to seed: ${msg}`);
+	process.exit(1);
+}
 
-// Default OUTSIDE any vault — a vault nested inside another vault can't be opened.
+// Default OUTSIDE any vault — a vault nested inside another can't be opened.
 const vault = resolve(arg("vault", join(homedir(), "fileclass-demo-vault")));
-const dot = join(vault, ".obsidian");
-const pluginOut = join(dot, "plugins", "fileclass");
+const force = process.argv.includes("--force");
+const MARKER = ".fileclass-demo-vault";
+
+// --- guards: never rm -rf real data ------------------------------------------
+if (vault === homedir() || vault === resolve("/")) fail(`"${vault}" is a protected directory.`);
+if (process.cwd() === vault || (process.cwd() + sep).startsWith(vault + sep)) {
+	fail(`"${vault}" is an ancestor of the current directory.`);
+}
+if (existsSync(vault) && readdirSync(vault).length && !existsSync(join(vault, MARKER)) && !force) {
+	fail(`"${vault}" exists and isn't a previous demo vault. Use a different --vault, or --force.`);
+}
 
 console.log(`Seeding demo vault at ${vault}`);
 rmSync(vault, { recursive: true, force: true });
+const pluginOut = join(vault, ".obsidian", "plugins", "fileclass");
 mkdirSync(pluginOut, { recursive: true });
+writeFileSync(join(vault, MARKER), "Fileclass onboarding demo vault — safe to delete.\n");
 
 // --- install the built plugin ------------------------------------------------
 for (const f of ["main.js", "manifest.json", "styles.css"]) {
 	const src = join(pluginDir, f);
-	if (!existsSync(src)) throw new Error(`Missing ${f} — run \`npm run build\` in the plugin first.`);
+	if (!existsSync(src)) fail(`missing ${f} — run \`npm run build\` in the plugin first.`);
 	cpSync(src, join(pluginOut, f));
 }
 
 const write = (rel, data) =>
 	writeFileSync(join(vault, rel), typeof data === "string" ? data : JSON.stringify(data, null, 2));
 
-// --- Obsidian config ---------------------------------------------------------
 write(".obsidian/community-plugins.json", ["fileclass"]);
-// A clean, legible look for video. Adjust to taste.
 write(".obsidian/appearance.json", { baseFontSize: 18, theme: "obsidian" });
 write(".obsidian/app.json", { promptDelete: false });
-// Fileclass settings: fileClasses live in Classes/.
-write(".obsidian/plugins/fileclass/data.json", { classFilesPath: "Classes/" });
 
-// --- content -----------------------------------------------------------------
-mkdirSync(join(vault, "Classes"), { recursive: true });
-mkdirSync(join(vault, "Library"), { recursive: true });
-
-// A ready-made "Book" fileClass with visual field types (Select / Number /
-// Color / Icon / Date) — the recording binds a note to it and fills the values.
-write(
-	"Classes/Book.md",
-	`---
-icon: book
-mapWithTag: false
-fields:
-  - name: status
-    id: fcStatus
-    type: Select
-    path: ""
-    options:
-      sourceType: ValuesList
-      valuesList:
-        "1": Reading list
-        "2": Reading
-        "3": Read
-        "4": Abandoned
-  - name: rating
-    id: fcRating
-    type: Number
-    path: ""
-    options:
-      min: 0
-      max: 5
-  - name: cover
-    id: fcCover
-    type: Color
-    path: ""
-    options: {}
-  - name: icon
-    id: fcIcon
-    type: Icon
-    path: ""
-    options: {}
-  - name: read
-    id: fcRead
-    type: Date
-    path: ""
-    options: {}
----
-
-The **Book** fileClass — status, rating, cover color, icon, read date.
-`
-);
-
-// A few book notes with plain frontmatter (no fileClass yet) — the live demo
-// gives them structure by creating a "Book" fileClass and binding them.
-const books = [
-	{ title: "The Left Hand of Darkness", author: "Ursula K. Le Guin", year: 1969 },
-	{ title: "Dune", author: "Frank Herbert", year: 1965 },
-	{ title: "Kindred", author: "Octavia E. Butler", year: 1979 },
-];
-for (const b of books) {
-	write(
-		`Library/${b.title}.md`,
-		`---\ntitle: ${b.title}\nauthor: ${b.author}\nyear: ${b.year}\n---\n\n# ${b.title}\n\nby ${b.author}\n`
-	);
-}
-
-// A short welcome note to open first in the recording.
-write(
-	"Welcome.md",
-	`# Fileclass — quick tour\n\nA schema for your frontmatter: typed, validated properties with guided input.\n\nWe'll create a **Book** fileClass, structure the notes in \`Library/\`, and generate a table.\n`
-);
+// NB: the Classes/ folder and the classFilesPath setting are created ON CAMERA
+// in step 1 — the seed only pre-installs the plugin (the store install opens
+// several separate windows in this build, too jumpy to record).
 
 console.log(`\nDone. Vault: ${vault}\n`);
-console.log("Next (see README.md):");
-console.log("  1. In Obsidian → Open another vault → Open folder as vault → pick the folder above (once).");
-console.log("  2. Turn off Restricted mode (trust) so the Fileclass + Bases plugins load.");
-console.log("  3. Quit Obsidian, then relaunch it with remote debugging:");
+console.log("One-time setup (off camera):");
+console.log("  1. Obsidian → Open another vault → Open folder as vault → pick the folder above.");
+console.log("  2. If prompted, turn on community plugins / trust; ensure Fileclass and core Bases are enabled.");
+console.log("  3. Quit Obsidian, relaunch with remote debugging:");
 console.log("       open -na Obsidian --args --remote-debugging-port=9222");
-console.log("     (it reopens the last vault = this one; if not, switch to it in the vault picker).");
-console.log("  4. node record.mjs");
+console.log("Then: start recording → node record.mjs 1  (intro) → node record.mjs 2  (create + fill)");

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default tseslint.config(
 			"docs/**",
 			"node_modules/**",
 			"tests/e2e/**",
-			"cli/**",
+			"demo/**",
 			"esbuild.config.mjs",
 			"version-bump.mjs",
 		],


### PR DESCRIPTION
Adds `demo/` — self-contained tooling to script and screen-record the Fileclass onboarding video by driving Obsidian over CDP (`puppeteer-core`). Not part of the plugin build; `demo/**` is eslint-ignored.

## How it works
- `seed.mjs` creates a throwaway vault with **only** the plugin installed (guards refuse to touch home/`/`/an ancestor of cwd or a non-demo dir). Everything else is created on camera.
- `lib/driver.mjs` connects to Obsidian (`--remote-debugging-port=9222`), shows step captions, and — crucially — **never clicks**. It types, sets `<select>`/date values, opens the palette, and detects results in the DOM.
- **Manual-click handoff:** every mouse click is the operator's. When the caption turns purple and ends with `…`, they do the named click; the driver watches the DOM and resumes automatically. Needed because the file right-click menu renders in a separate window the debug port can't reach — and it keeps the pointer natural on camera. No fake cursor (add one in post).

## The scenario (`record.mjs`, three idempotent acts)
1. **Set up** — install caption, create `Classes/`, set `classFilesPath`.
2. **Define a type + real notes** — create an **Author** fileClass (Date `birthdate` + Select `country`), then two authors: **Frank Herbert** via the command palette, **Arnaldur Indriðason** via the right-click menu (teaches both entry points).
3. **See / edit / connect** — create a Bases **table** for Author from its context menu, edit a value **in a table cell**, then a **Book** fileClass with a **File** field sourced from the Author table, and a **Dune** note linked to Frank Herbert.

Detectors key off the DOM (modal counts, suggester placeholders, frontmatter), not timing. Storytelling captions throughout; `scenario.md` + `README.md` document the flow and the handoff model.

Also: removed a dead `cli/**` entry and added `demo/**` to the eslint ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)