### PR TITLE
docs(demo): take 004 — Select, and a 60-second narration budget

### DIFF
--- a/demo/004_add_a_select_field/demo-vault/.obsidian/workspace.json
+++ b/demo/004_add_a_select_field/demo-vault/.obsidian/workspace.json
@@ -1,0 +1,60 @@
+{
+  "main": {
+    "id": "demo-main",
+    "type": "split",
+    "direction": "vertical",
+    "children": [
+      {
+        "id": "demo-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-note",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": { "file": "Dune.md", "mode": "source", "source": false }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "left": {
+    "id": "demo-left",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "children": [
+      {
+        "id": "demo-left-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-explorer",
+            "type": "leaf",
+            "state": { "type": "file-explorer", "state": { "sortOrder": "alphabetical" } }
+          }
+        ]
+      }
+    ]
+  },
+  "right": {
+    "id": "demo-right",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "collapsed": true,
+    "children": [
+      {
+        "id": "demo-right-tabs",
+        "type": "tabs",
+        "children": [
+          { "id": "demo-backlink", "type": "leaf", "state": { "type": "backlink", "state": {} } }
+        ]
+      }
+    ]
+  },
+  "active": "demo-note",
+  "lastOpenFiles": ["Dune.md", "The Lord of the Rings.md", "Tintin in Tibet.md"]
+}

--- a/demo/004_add_a_select_field/demo-vault/Classes/Book.md
+++ b/demo/004_add_a_select_field/demo-vault/Classes/Book.md
@@ -1,0 +1,15 @@
+---
+fields:
+  - name: publisher
+    id: kQ7mzT
+    type: Input
+    options: {}
+    path: ""
+  - name: pages
+    id: pG42nx
+    type: Number
+    options:
+      min: 1
+      max: 5000
+    path: ""
+---

--- a/demo/004_add_a_select_field/demo-vault/Dune.md
+++ b/demo/004_add_a_select_field/demo-vault/Dune.md
@@ -1,0 +1,10 @@
+---
+fileClass: Book
+publisher: Chilton Books
+pages: 412
+---
+Frank Herbert spent five years on desert ecology and the politics of water
+before Chilton Books — until then a publisher of car repair manuals — took the
+manuscript, in 1965.
+
+412 pages in that first edition, and not one of them wasted.

--- a/demo/004_add_a_select_field/demo-vault/The Lord of the Rings.md
+++ b/demo/004_add_a_select_field/demo-vault/The Lord of the Rings.md
@@ -1,0 +1,4 @@
+Allen & Unwin brought it out in three volumes from 1954, against Tolkien's wish
+for a single book. Mine is the 1991 paperback set, spines long gone.
+
+1178 pages across the three, appendices included.

--- a/demo/004_add_a_select_field/demo-vault/Tintin in Tibet.md
+++ b/demo/004_add_a_select_field/demo-vault/Tintin in Tibet.md
@@ -1,0 +1,4 @@
+Hergé's own favourite, drawn in the middle of a breakdown, and the only album
+with no villain in it. Casterman, 1960.
+
+62 pages, like every album in the series.

--- a/demo/004_add_a_select_field/scenario.yaml
+++ b/demo/004_add_a_select_field/scenario.yaml
@@ -1,0 +1,48 @@
+# Narration for take 004 — see ../SCENARIO.md for the format.
+# Starts where 003 ended: Book has publisher (Input) and pages (Number), and Dune
+# is filled in. Scope: the Select type with an inline values list, and the same
+# vocabulary reused on a second note. The note/base value sources are named in
+# one line but not shown — they belong to the File-field takes.
+title: "Fileclass — Select: the values you allow"
+description: "Give Book a genre that can only be one of the values you decide."
+doc: "fields/#where-allowed-values-come-from" # deep link used in the description
+tags: "select field, allowed values, note types"
+vault_name: "Demo"
+plugin: true
+settings:
+  classFilesPath: "Classes/"
+  fileClassAlias: "fileClass"
+initial_pause: 1500
+default_pause: 900
+
+steps:
+  - title: "Dune has a publisher and a page count. What kind of book is it?"
+    pause: 1400
+  - title: "A genre isn't free text — it's one of a few values you decide"
+    pause: 1600
+  - title: "Open the Book class, and add a field named genre"
+    pause: 1000
+  - title: "Its type is Select: one value out of a list"
+    pause: 1200
+  - title: "The list can come from a note or a base — today we'll type it"
+    pause: 1400
+  - title: "Add three values: Science fiction, Fantasy, Comics"
+    pause: 1600
+  - title: "Save the schema"
+    pause: 1200
+  - title: "Back in Dune, insert genre"
+    pause: 1200
+  - title: "No text box this time — just your three values"
+    pause: 1400
+  - title: "Pick Science fiction, and it's written as it stands"
+    pause: 1400
+  - title: "The same class fits other notes: give Tolkien's book its class"
+    pause: 1400
+  - title: "Insert its fields, and genre offers the very same three"
+    pause: 1600
+  - title: "Fantasy for that one"
+    pause: 1000
+  - title: "Two books, one vocabulary — no typos to reconcile later"
+    pause: 1800
+  - title: "That's what a Select buys you over a text field 🎉"
+    pause: 2200

--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -1,7 +1,8 @@
 # Demo series roadmap
 
 One take per atomic feature, ordered so a take only needs what earlier takes
-already showed. Every video stays under two minutes; most run about a minute.
+already showed. The budget is **60 seconds of narration**, which lands a finished
+video around two minutes — see [SCENARIO.md](SCENARIO.md#the-real-budget-60-seconds-of-narration).
 All subtitles are in English — non-English speakers turn on YouTube's captions.
 
 How to use this list: pick the next unrecorded take, propose its step list, get it
@@ -45,7 +46,7 @@ thread, and a tight smoke test of that type's input path.
 | # | Take | Feature | Vault gains | Status |
 | - | ---- | ------- | ----------- | ------ |
 | 003 | Number, and why it isn't text | `Number` (min/max/step) | `Book.pages` | ✅ [published](https://www.youtube.com/watch?v=W1KAokens_4) |
-| 004 | Select — the values you allow | `Select`, values list | `Book.genre` | |
+| 004 | Select — the values you allow | `Select`, inline values list | `Book.genre`, Tolkien typed | ✅ [published](https://www.youtube.com/watch?v=_kHMoXBNY7k) |
 | 005 | Boolean — the checkbox | `Boolean` | `Book.read` | |
 | 006 | Cycle — one click, next value | `Cycle` | `Book.status` | |
 | 007 | Date — a picker, and a display format | `Date`, default date format | `Book.published` | |

--- a/demo/SCENARIO.md
+++ b/demo/SCENARIO.md
@@ -138,7 +138,27 @@ Pause conventions that have felt right on camera:
 | reveal ("the fields appear, typed") | 1600–1800   |
 | closing line                        | 2000–2200   |
 
-## 5. Build `demo-vault/` — the smallest vault that makes the story possible
+### The real budget: 60 seconds of narration
+
+Don't count steps, count **spoken seconds** — and aim for **55 to 60**.
+
+The first four takes measured like this:
+
+| take | narration | finished video |
+| ---- | --------- | -------------- |
+| 001  | 60.6 s    | 1:51           |
+| 002  | 59.9 s    | 2:12           |
+| 003  | 68.4 s    | 1:52           |
+| 004  | 63.8 s    | 2:07           |
+
+The video runs **about twice the narration**: the difference is the operator
+acting on camera, and that ratio has held on every take. So a two-minute video
+means roughly a minute of voice, and a scenario that reads as 80 seconds of
+narration is already a 2:40 video — over budget before a single click.
+
+`node voiceover.mjs NNN --preview` prints the per-line and total durations, so the
+number is known *before* recording. Over budget? Cut a step or shorten a line —
+never shave the pauses, which is what makes a take readable.
 
 - Only what the viewer sees: notes, folders, `.base` files. Two or three notes is
   usually plenty, and their content should be prose that *wants* structure (the
@@ -173,9 +193,9 @@ node voiceover.mjs NNN --preview # renders the narration: hear it, and get its l
 
 Then re-read the printed script as a viewer: does it tell one story? Does every
 line correspond to something that exists in the UI? Does the vault contain what
-step 1 claims? The preview is the honest test of the "sayable out loud" rule — a
-line that sounds wrong spoken *is* wrong. Only after that, tell the operator it's
-ready to record.
+step 1 claims? Is the narration inside its 60-second budget? The preview is the
+honest test of the "sayable out loud" rule too — a line that sounds wrong spoken
+*is* wrong. Only after that, tell the operator it's ready to record.
 
 ## Running a take (operator's side)
 

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -310,6 +310,8 @@ the marker color.
 
 ## Where allowed values come from
 
+{{< video "004" >}}
+
 `Select`, `Cycle`, and `Multi` draw their allowed values from the field's option
 source:
 

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -20,3 +20,7 @@ other. Captions are English; YouTube translates them into your language.
 ## Number, and why it isn't text
 
 {{< video "003" >}}
+
+## Select: the values you allow
+
+{{< video "004" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -28,5 +28,15 @@
     "doc": "fields/#number-fields",
     "durationSeconds": 112,
     "privacyStatus": "public"
+  },
+  "004": {
+    "id": "_kHMoXBNY7k",
+    "url": "https://www.youtube.com/watch?v=_kHMoXBNY7k",
+    "title": "Fileclass #004 · Select: the values you allow",
+    "subject": "Select: the values you allow",
+    "scenario": "004_add_a_select_field",
+    "doc": "fields/#where-allowed-values-come-from",
+    "durationSeconds": 127,
+    "privacyStatus": "public"
   }
 }


### PR DESCRIPTION
Take 004 of the series, plus the pacing rule the first four takes make measurable.

## The take

Starts where 003 ended — `Book` with `publisher` and `pages`, Dune filled in — and
gives the class a `genre`: the `Select` type, an inline values list (*Science
fiction*, *Fantasy*, *Comics*), then the same three values reused on a second note.
Tolkien's book joins the class on camera, because that's the only way "one
vocabulary, no typos to reconcile" lands as a demonstration instead of a promise.
One line names the note and base value sources without showing them; they belong
to the `File` takes.

Published: https://www.youtube.com/watch?v=_kHMoXBNY7k (2:07), linked from the
**Where allowed values come from** section of `fields.md`.

## The 60-second budget

Four takes give a stable ratio — the finished video runs about **twice** its
narration:

| take | narration | video |
| ---- | --------- | ----- |
| 001  | 60.6 s    | 1:51  |
| 002  | 59.9 s    | 2:12  |
| 003  | 68.4 s    | 1:52  |
| 004  | 63.8 s    | 2:07  |

The difference is the operator acting on camera, which is exactly what should take
the time. But it means the roadmap's "under two minutes" is really **55–60 spoken
seconds**, and two of the four takes are already over. Counting steps was the wrong
proxy.

`SCENARIO.md` now states the budget with these measurements, and points at
`voiceover.mjs NNN --preview` — which prints the total *before* recording, so a
scenario can be trimmed on paper. When over: cut a step or shorten a line, never
shave the pauses, since those are what make a take readable.

`ROADMAP.md`'s header says the same, so the denser planned takes (024 inheritance,
030 bulk edit) get scoped against seconds rather than optimism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
