### PR TITLE
docs(demo): take 005 — Boolean, the checkbox

### DIFF
--- a/demo/005_add_a_boolean_field/demo-vault/.obsidian/workspace.json
+++ b/demo/005_add_a_boolean_field/demo-vault/.obsidian/workspace.json
@@ -1,0 +1,60 @@
+{
+  "main": {
+    "id": "demo-main",
+    "type": "split",
+    "direction": "vertical",
+    "children": [
+      {
+        "id": "demo-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-note",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": { "file": "Dune.md", "mode": "source", "source": false }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "left": {
+    "id": "demo-left",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "children": [
+      {
+        "id": "demo-left-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-explorer",
+            "type": "leaf",
+            "state": { "type": "file-explorer", "state": { "sortOrder": "alphabetical" } }
+          }
+        ]
+      }
+    ]
+  },
+  "right": {
+    "id": "demo-right",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "collapsed": true,
+    "children": [
+      {
+        "id": "demo-right-tabs",
+        "type": "tabs",
+        "children": [
+          { "id": "demo-backlink", "type": "leaf", "state": { "type": "backlink", "state": {} } }
+        ]
+      }
+    ]
+  },
+  "active": "demo-note",
+  "lastOpenFiles": ["Dune.md", "The Lord of the Rings.md", "Tintin in Tibet.md"]
+}

--- a/demo/005_add_a_boolean_field/demo-vault/Classes/Book.md
+++ b/demo/005_add_a_boolean_field/demo-vault/Classes/Book.md
@@ -1,0 +1,25 @@
+---
+fields:
+  - name: publisher
+    id: kQ7mzT
+    type: Input
+    options: {}
+    path: ""
+  - name: pages
+    id: pG42nx
+    type: Number
+    options:
+      min: 1
+      max: 5000
+    path: ""
+  - name: genre
+    id: gNr8wc
+    type: Select
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Science fiction
+        "2": Fantasy
+        "3": Comics
+    path: ""
+---

--- a/demo/005_add_a_boolean_field/demo-vault/Dune.md
+++ b/demo/005_add_a_boolean_field/demo-vault/Dune.md
@@ -1,0 +1,11 @@
+---
+fileClass: Book
+publisher: Chilton Books
+pages: 412
+genre: Science fiction
+---
+Frank Herbert spent five years on desert ecology and the politics of water
+before Chilton Books — until then a publisher of car repair manuals — took the
+manuscript, in 1965.
+
+412 pages in that first edition, and not one of them wasted.

--- a/demo/005_add_a_boolean_field/demo-vault/The Lord of the Rings.md
+++ b/demo/005_add_a_boolean_field/demo-vault/The Lord of the Rings.md
@@ -1,0 +1,10 @@
+---
+fileClass: Book
+publisher: ""
+pages: ""
+genre: Fantasy
+---
+Allen & Unwin brought it out in three volumes from 1954, against Tolkien's wish
+for a single book. Mine is the 1991 paperback set, spines long gone.
+
+1178 pages across the three, appendices included.

--- a/demo/005_add_a_boolean_field/demo-vault/Tintin in Tibet.md
+++ b/demo/005_add_a_boolean_field/demo-vault/Tintin in Tibet.md
@@ -1,0 +1,4 @@
+Hergé's own favourite, drawn in the middle of a breakdown, and the only album
+with no villain in it. Casterman, 1960.
+
+62 pages, like every album in the series.

--- a/demo/005_add_a_boolean_field/scenario.yaml
+++ b/demo/005_add_a_boolean_field/scenario.yaml
@@ -1,0 +1,42 @@
+# Narration for take 005 — see ../SCENARIO.md for the format.
+# Starts where 004 ended: Book has publisher, pages and genre; Dune is complete;
+# Tolkien's book is bound to the class with genre Fantasy and its other two fields
+# still empty (that's literally what insert-missing-fields left there).
+# Scope: the Boolean type, and the difference between false and unset.
+title: "Fileclass — Boolean: the checkbox"
+description: "Say which books you've read, with a switch instead of a word."
+doc: "fields/#available-field-types" # deep link used in the description
+tags: "boolean field, checkbox, typed properties"
+vault_name: "Demo"
+plugin: true
+settings:
+  classFilesPath: "Classes/"
+  fileClassAlias: "fileClass"
+initial_pause: 1500
+default_pause: 900
+
+steps:
+  - title: "Two books typed — and no way to say which one you've read"
+    pause: 1400
+  - title: "Read or not is a yes-or-no fact: that's a Boolean"
+    pause: 1600
+  - title: "Open the Book class and add a field named read"
+    pause: 1000
+  - title: "Type Boolean — nothing to configure, it's true or false"
+    pause: 1400
+  - title: "Save the schema"
+    pause: 1200
+  - title: "Insert it in Dune"
+    pause: 1200
+  - title: "The input is a switch, not the word true"
+    pause: 1400
+  - title: "Turn it on, and the frontmatter says read: true"
+    pause: 1600
+  - title: "Obsidian shows it as a checkbox in its own properties editor"
+    pause: 1600
+  - title: "Tolkien's book is still on the pile: insert read and save it off"
+    pause: 1600
+  - title: "false means not read; an empty field would mean nothing at all"
+    pause: 1800
+  - title: "Now your vault can answer: what haven't I read yet? 🎉"
+    pause: 2200

--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -47,7 +47,7 @@ thread, and a tight smoke test of that type's input path.
 | - | ---- | ------- | ----------- | ------ |
 | 003 | Number, and why it isn't text | `Number` (min/max/step) | `Book.pages` | ✅ [published](https://www.youtube.com/watch?v=W1KAokens_4) |
 | 004 | Select — the values you allow | `Select`, inline values list | `Book.genre`, Tolkien typed | ✅ [published](https://www.youtube.com/watch?v=_kHMoXBNY7k) |
-| 005 | Boolean — the checkbox | `Boolean` | `Book.read` | |
+| 005 | Boolean — the checkbox | `Boolean` (false vs unset) | `Book.read` | ✅ [published](https://www.youtube.com/watch?v=4BvyykBs-8s) |
 | 006 | Cycle — one click, next value | `Cycle` | `Book.status` | |
 | 007 | Date — a picker, and a display format | `Date`, default date format | `Book.published` | |
 | 008 | DateTime and Time | `DateTime`, `Time` | `Activity` class | |

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -43,6 +43,13 @@ Empty values are always valid — a field is optional unless a constraint says
 otherwise. `Lookup` and `Formula` (computed fields) are **out of scope** for
 Fileclass — use Bases views for reverse relations and computed columns.
 
+`Boolean` is the simplest of them: no options, a switch for input, and a real
+`true`/`false` in the frontmatter, which Obsidian renders as a checkbox in its own
+properties editor. Note that an **empty** boolean is not `false` — it says nothing,
+which is why *insert missing fields* leaves it blank rather than guessing.
+
+{{< video "005" >}}
+
 ## Required fields
 
 Any field can be marked **Required** in the schema editor (the toggle sits with

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -24,3 +24,7 @@ other. Captions are English; YouTube translates them into your language.
 ## Select: the values you allow
 
 {{< video "004" >}}
+
+## Boolean: the checkbox
+
+{{< video "005" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -38,5 +38,15 @@
     "doc": "fields/#where-allowed-values-come-from",
     "durationSeconds": 127,
     "privacyStatus": "public"
+  },
+  "005": {
+    "id": "4BvyykBs-8s",
+    "url": "https://www.youtube.com/watch?v=4BvyykBs-8s",
+    "title": "Fileclass #005 · Boolean: the checkbox",
+    "subject": "Boolean: the checkbox",
+    "scenario": "005_add_a_boolean_field",
+    "doc": "fields/#available-field-types",
+    "durationSeconds": 103,
+    "privacyStatus": "public"
   }
 }


### PR DESCRIPTION
Take 005: https://www.youtube.com/watch?v=4BvyykBs-8s (1:43)

Scope is the whole of `Boolean`, which is small: a switch for input, a real
`true`/`false` in the frontmatter — Obsidian renders it as a checkbox in its own
properties editor — and the distinction that's easy to miss: **an empty boolean is
not `false`**. It says nothing, which is why *insert missing fields* leaves it
blank rather than guessing. Reading the code before writing the script is what
surfaced that; the last two steps demonstrate it with `read: true` on Dune and
`read: false` on Tolkien's book.

`fields.md` gains a short paragraph right under the type table — where a reader
looking up Boolean lands — rather than a section of its own, since there are no
options to document.

## Fixture fidelity

The vault starts exactly where 004 left it, **including Tolkien's book with its
`publisher` and `pages` still empty**: that's what insert-missing-fields wrote on
camera in the previous take. Tidying it up off-screen would make every later take
start from a vault the viewer never saw.

## The budget holds

| take | narration | video |
| ---- | --------- | ----- |
| 001  | 60.6 s    | 1:51  |
| 002  | 59.9 s    | 2:12  |
| 003  | 68.4 s    | 1:52  |
| 004  | 63.8 s    | 2:07  |
| 005  | 50.1 s    | 1:43  |

Five takes, same ×2 ratio between narration and finished video — the rule added in
#65 predicted 005's length before it was recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
