### PR TITLE
chore(demo): stamp the plugin version, and smoke-test a script before recording

### DIFF
--- a/demo/PUBLISHING.md
+++ b/demo/PUBLISHING.md
@@ -140,6 +140,15 @@ is reported with the `--finish` command to retry it, and the URL is printed anyw
 
 Nothing is deleted between takes, so an older release stays reproducible.
 
+## The version a take was recorded against
+
+The description ends with **"Recorded with Fileclass X.Y.Z"** — the version the
+fixture installed, journalled by `record.mjs` and carried into `youtube.json` and the
+doc card. The series will outlive several releases; a viewer deserves to know how old
+what they are watching is, and you deserve to know which takes to re-shoot after a UI
+change. Take 001 has no stamp: it installs the plugin from the community store on
+camera, so the build is whatever the store served that day.
+
 ## Why a caption track when the subtitles are burned in
 
 The burned-in bar is what makes a video readable with the sound off and captions

--- a/demo/README.md
+++ b/demo/README.md
@@ -10,6 +10,7 @@ a human's.
 demo/
   record.mjs                        # node record.mjs 001      — run a take
   voiceover.mjs                     # node voiceover.mjs 001   — hear / build the narration
+  smoke.mjs                         # node smoke.mjs 001      — check a script against the app
   publish.mjs                       # node publish.mjs 001 …   — package + upload
   sync-docs.mjs                     # node sync-docs.mjs       — videos back into the docs
   lib/                              # scenarios, vault staging, subtitles, voice, YouTube
@@ -59,6 +60,21 @@ it), `--title-card` (show the title full-screen during the intro), `--speak`
 Every take journals when each subtitle appeared, in
 `~/fileclass-demos/takes/<scenario>-<stamp>.json` — that's what the voice-over
 uses.
+
+## Smoke-test a scenario before recording
+
+```bash
+node smoke.mjs 007          # stage, launch, report, and stay open
+node smoke.mjs 007 --close  # just the report
+```
+
+Stages the take's vault, opens it in a real Obsidian and reports what the script
+promises against what the app exposes: the plugin version and indexed classes, each
+note as the take will find it (class, frontmatter keys, fields not yet inserted),
+and — per step — the commands, settings and field types it names. A step that says to
+*run* something without naming a known command, or to *set* something in the settings
+without naming one, is flagged. Obsidian stays open so the critical gestures can be
+tried by hand before you hit Record.
 
 ## Voice-over
 

--- a/demo/SCENARIO.md
+++ b/demo/SCENARIO.md
@@ -212,14 +212,32 @@ make a take readable.
 ```bash
 node record.mjs NNN --dry        # parses the yaml, prints the script + pauses
 node voiceover.mjs NNN --preview # renders the narration: hear it, and get its length
+node smoke.mjs NNN               # opens the staged vault and checks the script against it
 ```
 
-Then re-read the printed script as a viewer: does it tell one story? Does every
-line correspond to something that exists in the UI? Does the vault contain what
-step 1 claims? Is the narration inside its 60-second budget, and how many steps
-ask for typing? The preview is the
-honest test of the "sayable out loud" rule too — a line that sounds wrong spoken
-*is* wrong. Only after that, tell the operator it's ready to record.
+Then re-read the printed script as a viewer: does it tell one story? Is the
+narration inside its 60-second budget, and how many steps ask for typing? The
+preview is the honest test of the "sayable out loud" rule too — a line that sounds
+wrong spoken *is* wrong.
+
+**`smoke.mjs` answers the question you can't answer by reading**: does the UI still
+match the words? It stages the vault, opens it in a real Obsidian, and reports
+
+- the plugin version, whether Bases is available, the classes indexed;
+- each note as the take will find it — its class, its frontmatter keys, and which
+  declared fields are not inserted yet (a fixture typo shows up here);
+- for every step, the **commands, settings and field types it names** that the app
+  actually exposes — and a warning when a step says to *run* something without
+  naming a known command, or to *set* something in the settings without naming a
+  setting of that pane.
+
+That last check is the one that earns its keep: a subtitle naming a command whose
+name has drifted reads fine on paper and fails on camera. Take 003 was recorded
+against an input that silently refused what its own script asked the viewer to type.
+
+Obsidian stays open on the staged vault afterwards, so the two or three gestures the
+take depends on can be tried by hand before Record. Only after that, tell the
+operator it's ready to record.
 
 ## Running a take (operator's side)
 

--- a/demo/lib/scriptScan.mjs
+++ b/demo/lib/scriptScan.mjs
@@ -1,0 +1,87 @@
+/*
+ * Matching what a scenario *says* against what the app *exposes*.
+ *
+ * Subtitles name real UI — a command, a setting, a field type — so when one of
+ * those drifts the take lies. This scans each step for names the running plugin
+ * actually has, and flags a step that promises one without naming any.
+ *
+ * Pure on purpose: the facts come from CDP (smoke.mjs), the judgement is here and
+ * can be checked without launching anything.
+ */
+
+/** A step that tells the viewer to run something. */
+const CLAIMS_COMMAND = /\b(run|command palette|palette)\b/i;
+/**
+ * A step that *sets* something in the settings — "open the settings" is
+ * navigation and names nothing, which is fine; "set X in the settings" should
+ * name what it sets.
+ */
+const CLAIMS_SETTING = /\bsettings?\b/i;
+const SETS_SOMETHING = /\b(set|change|fill|point|enter|type)\b/i;
+
+/** Names of `list` that appear in `title`, case-insensitively. */
+export function mentions(title, list) {
+	const lower = title.toLowerCase();
+	return list.filter((name) => name && lower.includes(name.toLowerCase()));
+}
+
+/**
+ * Commands a subtitle names, allowing the natural shortening: a script says
+ * "run Insert missing fields" where the command is "Insert missing fields in
+ * current file". A prefix of three words or more counts (or the whole name when
+ * it is shorter), which keeps "Create a class" from matching "Create a base for a
+ * class".
+ */
+export function mentionsCommands(title, commands) {
+	const lower = title.toLowerCase();
+	return commands.filter((name) => {
+		const words = name.split(/\s+/);
+		if (words.length <= 3) return lower.includes(name.toLowerCase());
+		for (let n = words.length; n >= 3; n--) {
+			if (lower.includes(words.slice(0, n).join(" ").toLowerCase())) return true;
+		}
+		return false;
+	});
+}
+
+/**
+ * Field types are matched as capitalised words, so "The input is a switch" isn't
+ * read as the `Input` type while "type Input" is.
+ */
+export function mentionsTypes(title, types) {
+	return types.filter((type) => new RegExp(`\\b${type}\\b`).test(title));
+}
+
+/**
+ * One verdict per step: what it names, and whether it promises UI it doesn't name.
+ * @param steps    scenario steps ({ title })
+ * @param facts    { commands, settingNames, fieldTypes } read from the app
+ */
+export function scanScript(steps, { commands = [], settingNames = [], fieldTypes = [] }) {
+	return steps.map((step, i) => {
+		const foundCommands = mentionsCommands(step.title, commands);
+		const foundSettings = mentions(step.title, settingNames);
+		const foundTypes = mentionsTypes(step.title, fieldTypes);
+		const claimsCommand = CLAIMS_COMMAND.test(step.title) && !foundCommands.length;
+		const claimsSetting =
+			CLAIMS_SETTING.test(step.title) && SETS_SOMETHING.test(step.title) && !foundSettings.length;
+		return {
+			index: i + 1,
+			title: step.title,
+			commands: foundCommands,
+			settings: foundSettings,
+			types: foundTypes,
+			claimsCommand,
+			claimsSetting,
+			suspicious: claimsCommand || claimsSetting,
+		};
+	});
+}
+
+/** FIELD_TYPES, read from the plugin source so the list can't drift. */
+export function fieldTypesFromSource(source) {
+	const start = source.indexOf("FIELD_TYPES = [");
+	const end = source.indexOf("] as const", start);
+	if (start === -1 || end === -1) return [];
+	return [...source.slice(start, end).matchAll(/"([A-Za-z]+)"/g)].map((m) => m[1]);
+}

--- a/demo/lib/stage.mjs
+++ b/demo/lib/stage.mjs
@@ -89,6 +89,17 @@ function refuse(msg) {
 	throw new Error(`Refusing to run: ${msg}`);
 }
 
+/** Version of the plugin build in `pluginDir` — what a take records against. */
+export function pluginVersion(pluginDir) {
+	const manifest = join(pluginDir, "manifest.json");
+	if (!existsSync(manifest)) return null;
+	try {
+		return JSON.parse(readFileSync(manifest, "utf8")).version ?? null;
+	} catch {
+		return null;
+	}
+}
+
 /** Absolute path of the vault a scenario runs in (id keeps takes separate). */
 export function runVaultPath(scenario) {
 	return join(RUNS_DIR, scenario.id, scenario.vaultName);

--- a/demo/package.json
+++ b/demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "record": "node record.mjs",
     "voiceover": "node voiceover.mjs",
+    "smoke": "node smoke.mjs",
     "publish": "node publish.mjs",
     "sync-docs": "node sync-docs.mjs"
   },

--- a/demo/publish.mjs
+++ b/demo/publish.mjs
@@ -36,12 +36,13 @@ import { homedir } from "node:os";
 import { cuesFromTake, toSrt } from "./lib/captions.mjs";
 import { loadScenario } from "./lib/scenario.mjs";
 import { syncDocs } from "./sync-docs.mjs";
-import { latestTakeLog, takesDir } from "./lib/stage.mjs";
+import { latestTakeLog, pluginVersion, takesDir } from "./lib/stage.mjs";
 import { buildVoiceTrack, syncShift } from "./lib/track.mjs";
 import { DEFAULT_RATE, hasFfmpeg, mux, resolveVoice } from "./lib/voice.mjs";
 import * as yt from "./lib/youtube.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(here, "..");
 const flag = (name) => process.argv.includes(`--${name}`);
 const opt = (name, fallback) => {
 	const i = process.argv.indexOf(`--${name}`);
@@ -96,7 +97,7 @@ function chapters(cues, durationMs) {
 	return [{ at: "0:00", text: spaced[0].text }, ...spaced.slice(1).map((c) => ({ at: clock(c.startMs), text: c.text }))];
 }
 
-function description(scenario, cues, links, durationMs) {
+function description(scenario, cues, links, durationMs, pluginVersion) {
 	const marks = chapters(cues, durationMs);
 	const parts = [scenario.description || scenario.title, ""];
 	parts.push("In this minute:");
@@ -108,6 +109,9 @@ function description(scenario, cues, links, durationMs) {
 	parts.push("");
 	if (links.doc) parts.push(`Docs: ${links.doc}`);
 	if (links.playlist) parts.push(`The whole series: ${links.playlist}`);
+	// Last line: the build this was recorded against. The series outlives releases,
+	// and a viewer deserves to know how old what they're watching is.
+	if (pluginVersion) parts.push("", `Recorded with Fileclass ${pluginVersion}.`);
 	const text = parts.join("\n");
 	return text.length > 4900 ? `${text.slice(0, 4900)}…` : text;
 }
@@ -237,6 +241,9 @@ async function main() {
 		);
 	}
 
+	// The take log carries the version it recorded against; fall back to the build
+	// on disk for takes journalled before this was stamped.
+	const recordedWith = take.pluginVersion ?? (scenario.plugin ? pluginVersion(pluginDir) : null);
 	const stamp = basename(takePath).replace(/\.json$/, "");
 	const outDir = join(homedir(), "fileclass-demos", "releases", stamp);
 	mkdirSync(outDir, { recursive: true });
@@ -286,11 +293,12 @@ async function main() {
 	const meta = {
 		scenario: scenario.id,
 		title: youtubeTitle(scenario),
-		description: description(scenario, cues, { doc: docUrl, playlist: "" }, take.endedAt),
+		description: description(scenario, cues, { doc: docUrl, playlist: "" }, take.endedAt, recordedWith),
 		tags: [...new Set([...BASE_TAGS, ...scenario.tags])],
 		categoryId: cfg.categoryId,
 		privacyStatus: visibility,
 		language: cfg.language,
+		recordedWith,
 		files: { video: finalVideo, captions: srt },
 		take: takePath,
 		...(previous?.result ? { result: previous.result } : {}),
@@ -315,7 +323,8 @@ async function main() {
 		scenario,
 		cues,
 		{ doc: docUrl, playlist: yt.playlistUrl(playlistId) },
-		take.endedAt
+		take.endedAt,
+		recordedWith
 	);
 
 	let lastPct = -1;

--- a/demo/record.mjs
+++ b/demo/record.mjs
@@ -29,6 +29,7 @@ import {
 	captureVaultRegistry,
 	launchObsidian,
 	obsidianPids,
+	pluginVersion,
 	quitObsidian,
 	relaunchObsidian,
 	runVaultPath,
@@ -185,7 +186,16 @@ async function main() {
 	// is what lets voiceover.mjs land each line on the right frame.
 	const t0 = Date.now();
 	const at = () => Date.now() - t0;
-	const log = { scenario: scenario.id, title: scenario.title, voice, rate, steps: [] };
+	// The version the take records against: what the fixture installed, or null
+	// when the plugin is installed from the store on camera (take 001).
+	const log = {
+		scenario: scenario.id,
+		title: scenario.title,
+		pluginVersion: scenario.plugin ? pluginVersion(pluginDir) : null,
+		voice,
+		rate,
+		steps: [],
+	};
 
 	if (titleCard) {
 		await stage.show(scenario.title, { title: true });

--- a/demo/smoke.mjs
+++ b/demo/smoke.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/*
+ * Checks a scenario against a live Obsidian before you record it.
+ *
+ *   node smoke.mjs 007            # stage the vault, launch, report, keep it open
+ *   node smoke.mjs 007 --close    # …and quit when the report is printed
+ *   node smoke.mjs 007 --attach   # report against the Obsidian already running
+ *
+ * Why: a subtitle names real UI — a command, a setting, a field type. When one of
+ * those drifts, the take lies, and you only find out on camera. Take 003 was
+ * recorded against an input that silently refused what its own script asked the
+ * viewer to type; that class of surprise is what this catches, in the two minutes
+ * before Record rather than the twenty after.
+ *
+ * It reports, it never fixes: everything it prints is either a fact about the
+ * staged vault or a phrase in the script that matches nothing in the app.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline/promises";
+
+import { loadScenario } from "./lib/scenario.mjs";
+import {
+	captureVaultRegistry,
+	launchObsidian,
+	obsidianPids,
+	pluginVersion,
+	quitObsidian,
+	relaunchObsidian,
+	runVaultPath,
+	sleep,
+	stageVault,
+	wipeVault,
+} from "./lib/stage.mjs";
+import { fieldTypesFromSource, scanScript } from "./lib/scriptScan.mjs";
+import { connect } from "./lib/subtitles.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(here, "..");
+const flag = (name) => process.argv.includes(`--${name}`);
+const opt = (name, fallback) => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s) => `\x1b[1m${s}\x1b[0m`;
+const warn = (s) => `\x1b[33m${s}\x1b[0m`;
+const ok = (s) => `\x1b[32m${s}\x1b[0m`;
+
+const scenario = loadScenario(here, process.argv.slice(2).find((a) => !a.startsWith("--")));
+const port = opt("port", process.env.OBSIDIAN_CDP_PORT || "9222");
+const attach = flag("attach");
+
+let registry = null;
+let launched = false;
+let staged = false;
+let quitTheirs = false;
+
+async function teardown() {
+	if (launched) await quitObsidian();
+	registry?.restore();
+	if (staged) wipeVault(scenario);
+	if (quitTheirs) relaunchObsidian();
+}
+
+/** Everything the app can tell us about the staged vault, in one round trip. */
+async function inspect(stage) {
+	// The settings pane is DOM-only, so it has to be open to read its labels.
+	await stage.appPage.evaluate(() => {
+		window.app.setting.open();
+		window.app.setting.openTabById("fileclass");
+	});
+	await sleep(700);
+	await stage.refresh();
+
+	let settingNames = [];
+	for (const page of stage.pages) {
+		const names = await page
+			.evaluate(() =>
+				[...document.querySelectorAll(".mod-settings .setting-item-name")]
+					.map((e) => e.textContent?.trim())
+					.filter(Boolean)
+			)
+			.catch(() => []);
+		if (names.length) settingNames = names;
+	}
+
+	const facts = await stage.appPage.evaluate(() => {
+		const app = window.app;
+		const p = app.plugins.plugins.fileclass;
+		const commands = Object.values(app.commands.commands)
+			.filter((c) => c.id.startsWith("fileclass:"))
+			.map((c) => c.name.replace(/^Fileclass:\s*/, ""));
+		const notes = app.vault
+			.getMarkdownFiles()
+			.map((f) => ({
+				path: f.path,
+				classes: p.index.getFileClasses(f),
+				fields: p.index.getFields(f).map((x) => `${x.name}:${x.type}`),
+				keys: Object.keys(app.metadataCache.getFileCache(f)?.frontmatter ?? {}),
+			}))
+			.sort((a, b) => a.path.localeCompare(b.path));
+		return {
+			version: p?.manifest?.version ?? null,
+			basesAvailable: !!p?.basesAvailable,
+			classNames: p.index.fileClassNames,
+			commands,
+			notes,
+		};
+	});
+
+	await stage.appPage.evaluate(() => window.app.setting.close());
+	return { ...facts, settingNames };
+}
+
+function report(facts) {
+	console.log(`\n${bold(scenario.title)}  ${dim(`(${scenario.id})`)}`);
+	console.log(
+		dim(
+			`plugin ${facts.version ?? "?"} · Bases ${facts.basesAvailable ? "available" : warn("unavailable")}` +
+				` · classes: ${facts.classNames.join(", ") || "(none)"}`
+		)
+	);
+
+	console.log(`\n${bold("Vault as the take will find it")}`);
+	for (const n of facts.notes) {
+		const declared = n.fields.map((f) => f.split(":")[0]);
+		const missing = n.classes.length ? declared.filter((name) => !n.keys.includes(name)) : [];
+		const bits = [
+			n.classes.length ? `class ${n.classes.join("+")}` : dim("no class"),
+			n.keys.length ? `keys ${n.keys.join(", ")}` : dim("no frontmatter"),
+		];
+		console.log(`  ${n.path}\n    ${bits.join(" · ")}`);
+		if (missing.length) console.log(`    ${dim(`fields not yet inserted: ${missing.join(", ")}`)}`);
+	}
+
+	console.log(`\n${bold("What the script names")}`);
+	const scan = scanScript(scenario.steps, {
+		commands: facts.commands,
+		settingNames: facts.settingNames,
+		fieldTypes: FIELD_TYPES,
+	});
+	for (const step of scan) {
+		const found = [
+			...step.commands.map((c) => `command "${c}"`),
+			...step.settings.map((x) => `setting "${x}"`),
+			...step.types.map((t) => `type ${t}`),
+		];
+		const line = `  ${String(step.index).padStart(2)}. ${step.title}`;
+		console.log(step.suspicious ? warn(line) : line);
+		if (found.length) console.log(dim(`      ${found.join(" · ")}`));
+		if (step.claimsCommand) console.log(warn("      says to run something, but names no known command"));
+		if (step.claimsSetting) console.log(warn("      mentions settings, but names no setting of this pane"));
+	}
+
+	const suspicious = scan.filter((s) => s.suspicious).length;
+	console.log(
+		suspicious
+			? warn(`\n${suspicious} step(s) to re-read: the UI may have drifted from the script.`)
+			: ok("\nEvery step that names UI matches something the app exposes.")
+	);
+}
+
+/** The plugin's own type list, read from source so it can't drift. */
+const FIELD_TYPES = fieldTypesFromSource(
+	readFileSync(resolve(pluginDir, "src/schema/field.ts"), "utf8")
+);
+
+async function main() {
+	let vaultPath = runVaultPath(scenario);
+	if (!attach) {
+		if (obsidianPids().length) {
+			const rl = createInterface({ input: process.stdin, output: process.stdout });
+			const answer = flag("yes")
+				? "y"
+				: (await rl.question("Obsidian is running — quit it for the smoke test? [Y/n] ")).trim();
+			rl.close();
+			if (answer && !/^y(es)?$/i.test(answer)) process.exit(1);
+			quitTheirs = true;
+			await quitObsidian();
+		}
+		vaultPath = stageVault(scenario, pluginDir);
+		staged = true;
+		console.log(dim(`Staged   ${vaultPath} (plugin ${pluginVersion(pluginDir) ?? "?"})`));
+		registry = captureVaultRegistry(vaultPath);
+		await launchObsidian(port);
+		launched = true;
+	}
+
+	const stage = await connect(port);
+	if (!attach) await stage.waitForVault(vaultPath);
+	await sleep(600); // let the index settle after load
+	report(await inspect(stage));
+	stage.disconnect();
+
+	if (flag("close") || attach) return;
+	console.log(
+		dim(
+			"\nObsidian stays open on the staged vault — play the steps by hand if you want.\n" +
+				"Press Enter here to close it and reset the vault."
+		)
+	);
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	await rl.question("");
+	rl.close();
+}
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+	process.on(sig, async () => {
+		await teardown();
+		process.exit(130);
+	});
+}
+
+main()
+	.then(() => teardown())
+	.catch(async (err) => {
+		await teardown();
+		console.error(`\n${err?.message || err}\n`);
+		process.exit(1);
+	});

--- a/demo/sync-docs.mjs
+++ b/demo/sync-docs.mjs
@@ -84,6 +84,7 @@ export async function publishedVideos() {
 			scenario: scenario.id,
 			doc: scenario.doc || "",
 			durationSeconds: await duration(dir, meta),
+			recordedWith: meta.recordedWith ?? null,
 			privacyStatus: meta.result.privacyStatus ?? "unknown",
 		};
 	}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -7,6 +7,7 @@
     "scenario": "001_install_and_param_fileclass",
     "doc": "settings/#core",
     "durationSeconds": 111,
+    "recordedWith": null,
     "privacyStatus": "public"
   },
   "002": {
@@ -17,6 +18,7 @@
     "scenario": "002_create_your_first_fileclass",
     "doc": "schema/#fields",
     "durationSeconds": 132,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   },
   "003": {
@@ -27,6 +29,7 @@
     "scenario": "003_add_a_number_field",
     "doc": "fields/#number-fields",
     "durationSeconds": 112,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   },
   "004": {
@@ -37,6 +40,7 @@
     "scenario": "004_add_a_select_field",
     "doc": "fields/#where-allowed-values-come-from",
     "durationSeconds": 127,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   },
   "005": {
@@ -47,6 +51,7 @@
     "scenario": "005_add_a_boolean_field",
     "doc": "fields/#available-field-types",
     "durationSeconds": 103,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   },
   "006": {
@@ -57,6 +62,7 @@
     "scenario": "006_cycle_through_values",
     "doc": "ui/#one-gesture-per-field-type",
     "durationSeconds": 101,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   },
   "007": {
@@ -67,6 +73,7 @@
     "scenario": "007_add_a_date_field",
     "doc": "fields/#which-format-is-written",
     "durationSeconds": 174,
+    "recordedWith": "0.1.1",
     "privacyStatus": "public"
   }
 }

--- a/docs/layouts/shortcodes/video.html
+++ b/docs/layouts/shortcodes/video.html
@@ -27,7 +27,7 @@
     <span class="play" aria-hidden="true"></span>
     <span class="txt">
       <strong>Watch: {{ $v.subject }}</strong>
-      <small>Fileclass #{{ $key }}{{ with $mins }} · {{ . }}{{ end }} · on YouTube</small>
+      <small>Fileclass #{{ $key }}{{ with $mins }} · {{ . }}{{ end }}{{ with $v.recordedWith }} · recorded with {{ . }}{{ end }} · on YouTube</small>
     </span>
   </a>
 {{ end }}


### PR DESCRIPTION
The two gaps the seven-take retrospective made visible.

## Which build a take shows

Nothing said which version a video was recorded against, and the series will outlive
several releases. `record.mjs` now journals the version the fixture installed, the
description ends with **"Recorded with Fileclass X.Y.Z"**, and the doc card reads
`· recorded with 0.1.1`. The seven published releases are backfilled.

Take 001 has no stamp on purpose: it installs the plugin from the community store on
camera, so the build is whatever the store served that day.

## Whether the UI still matches the words

```bash
node smoke.mjs 007          # stage, launch, report, stay open
node smoke.mjs 007 --close  # just the report
```

Stages the take's vault, opens it in a real Obsidian, and reports:

- plugin version, whether Bases is available, the classes indexed;
- **each note as the take will find it** — class, frontmatter keys, and which declared
  fields are not inserted yet, so a fixture typo surfaces before Record;
- **per step, the commands, settings and field types it names** that the app actually
  exposes — and a warning when a step says to *run* something without naming a known
  command, or to *set* something in the settings without naming one.

Then it leaves Obsidian open on the staged vault, so the two or three gestures a take
depends on can be tried by hand.

That last check is what earns its keep. Take 003 was recorded against an input that
silently refused what its own script asked the viewer to type — reading the script
could not have revealed it, and twenty minutes of recording did.

## The judgement is testable

`lib/scriptScan.mjs` holds the matching, pure and checkable without launching
anything. That's how its two false-positive classes were found and fixed before this
shipped:

- a script legitimately **shortens** a command — "run Insert missing fields" for
  *Insert missing fields in current file* — so a three-word-or-longer prefix counts,
  which still keeps "Create a class" from matching *Create a base for a class*;
- **"open the settings" is navigation**, not a setting: a step is only expected to
  name one when it also *sets* something.

Run over the seven existing scenarios it now flags exactly one step — 007's *"Set one
default per type in the settings"* — which indeed names no setting. 007 is published;
the flag stands as the tool's first true positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
