### PR TITLE
docs(demo): take 008 — DateTime and Time, and a smoke test that waits

### DIFF
--- a/demo/008_datetime_and_time/demo-vault/.obsidian/workspace.json
+++ b/demo/008_datetime_and_time/demo-vault/.obsidian/workspace.json
@@ -1,0 +1,60 @@
+{
+  "main": {
+    "id": "demo-main",
+    "type": "split",
+    "direction": "vertical",
+    "children": [
+      {
+        "id": "demo-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-note",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": { "file": "Reading group.md", "mode": "source", "source": false }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "left": {
+    "id": "demo-left",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "children": [
+      {
+        "id": "demo-left-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-explorer",
+            "type": "leaf",
+            "state": { "type": "file-explorer", "state": { "sortOrder": "alphabetical" } }
+          }
+        ]
+      }
+    ]
+  },
+  "right": {
+    "id": "demo-right",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "collapsed": true,
+    "children": [
+      {
+        "id": "demo-right-tabs",
+        "type": "tabs",
+        "children": [
+          { "id": "demo-backlink", "type": "leaf", "state": { "type": "backlink", "state": {} } }
+        ]
+      }
+    ]
+  },
+  "active": "demo-note",
+  "lastOpenFiles": ["Reading group.md", "Dune.md", "The Lord of the Rings.md"]
+}

--- a/demo/008_datetime_and_time/demo-vault/Classes/Book.md
+++ b/demo/008_datetime_and_time/demo-vault/Classes/Book.md
@@ -1,0 +1,45 @@
+---
+fields:
+  - name: publisher
+    id: kQ7mzT
+    type: Input
+    options: {}
+    path: ""
+  - name: pages
+    id: pG42nx
+    type: Number
+    options:
+      min: 1
+      max: 5000
+    path: ""
+  - name: genre
+    id: gNr8wc
+    type: Select
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Science fiction
+        "2": Fantasy
+        "3": Comics
+    path: ""
+  - name: read
+    id: rD5tqB
+    type: Boolean
+    options: {}
+    path: ""
+  - name: ownership
+    id: oWn5hp
+    type: Cycle
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Wanted
+        "2": Owned
+        "3": Lent out
+    path: ""
+  - name: published
+    id: pBl9dt
+    type: Date
+    options: {}
+    path: ""
+---

--- a/demo/008_datetime_and_time/demo-vault/Dune.md
+++ b/demo/008_datetime_and_time/demo-vault/Dune.md
@@ -1,0 +1,14 @@
+---
+fileClass: Book
+publisher: Chilton Books
+pages: 412
+genre: Science fiction
+read: true
+ownership: Owned
+published: 1965-08-01
+---
+Frank Herbert spent five years on desert ecology and the politics of water
+before Chilton Books — until then a publisher of car repair manuals — took the
+manuscript, in 1965.
+
+412 pages in that first edition, and not one of them wasted.

--- a/demo/008_datetime_and_time/demo-vault/Reading group.md
+++ b/demo/008_datetime_and_time/demo-vault/Reading group.md
@@ -1,0 +1,4 @@
+The reading group meets at the library on the second Thursday of the month.
+Next session: 10 September 2026, 7 pm — doors at 6:30.
+
+Dune this time; bring the Fremen chapters.

--- a/demo/008_datetime_and_time/demo-vault/The Lord of the Rings.md
+++ b/demo/008_datetime_and_time/demo-vault/The Lord of the Rings.md
@@ -1,0 +1,11 @@
+---
+fileClass: Book
+publisher: ""
+pages: ""
+genre: Fantasy
+read: false
+---
+Allen & Unwin brought it out in three volumes from 1954, against Tolkien's wish
+for a single book. Mine is the 1991 paperback set, spines long gone.
+
+1178 pages across the three, appendices included.

--- a/demo/008_datetime_and_time/demo-vault/Tintin in Tibet.md
+++ b/demo/008_datetime_and_time/demo-vault/Tintin in Tibet.md
@@ -1,0 +1,4 @@
+Hergé's own favourite, drawn in the middle of a breakdown, and the only album
+with no villain in it. Casterman, 1960.
+
+62 pages, like every album in the series.

--- a/demo/008_datetime_and_time/scenario.yaml
+++ b/demo/008_datetime_and_time/scenario.yaml
@@ -1,0 +1,46 @@
+# Narration for take 008 — see ../SCENARIO.md for the format.
+# Starts where 007 ended: Book has six fields including published (Date, no format
+# of its own), Dune is complete. Scope: DateTime vs Time — what each one *is*, and
+# the input each one gets. No format typing: 007 showed that, and typing is what
+# makes a take run long.
+title: "Fileclass — DateTime and Time"
+description: "A point in time, and a time of day: two types, two inputs."
+doc: "fields/#date-fields-date--datetime--time" # deep link used in the description
+tags: "datetime field, time field, date picker"
+vault_name: "Demo"
+plugin: true
+settings:
+  classFilesPath: "Classes/"
+  fileClassAlias: "fileClass"
+initial_pause: 1500
+default_pause: 900
+
+steps:
+  - title: "A reading group note, its next session buried in a sentence"
+    pause: 1600
+  - title: "Not a Book — an Activity, so it needs its own class"
+    pause: 1600
+  - title: "Create a class named Activity"
+    pause: 1000
+  - title: "Add a field: starts, type DateTime"
+    pause: 1200
+  - title: "A DateTime is one value: a date and a clock together"
+    pause: 1800
+  - title: "Add another: doors, type Time"
+    pause: 1200
+  - title: "A Time has no date: the hour the doors open, every session"
+    pause: 1800
+  - title: "Save, bind the note to Activity, insert its fields"
+    pause: 1400
+  - title: "The DateTime input is a calendar and a clock"
+    pause: 1400
+  - title: "Pick the tenth of September, at seven in the evening"
+    pause: 1400
+  - title: "The Time input is just a clock, and it won't ask for seconds"
+    pause: 1600
+  - title: "Half past six"
+    pause: 1000
+  - title: "Both stored ISO, each type with its own default"
+    pause: 1800
+  - title: "A point in time, a time of day, and the vault knows which 🎉"
+    pause: 2200

--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -51,7 +51,7 @@ thread, and a tight smoke test of that type's input path.
 | 005 | Boolean — the checkbox | `Boolean` (false vs unset) | `Book.read` | ✅ [published](https://www.youtube.com/watch?v=4BvyykBs-8s) |
 | 006 | Cycle — one click, next value | `Cycle`, one gesture per type, Alt-click | `Book.ownership` | ✅ [published](https://www.youtube.com/watch?v=F6fgdtexSRQ) |
 | 007 | Date — the format you store | `Date`, picker, three-level write format, format check | `Book.published` | ✅ [published](https://www.youtube.com/watch?v=1c2a1usAPRU) |
-| 008 | DateTime and Time | `DateTime`, `Time` | `Activity` class | |
+| 008 | DateTime and Time | `DateTime`, `Time` (a point in time vs a time of day) | `Activity` class, `Reading group` note | ✅ [published](https://www.youtube.com/watch?v=bInkg1jLOmM) |
 | 009 | Duration | `Duration` | `Album` class, `Album.length` | |
 | 010 | Cycling an interval, and the next date | `CycleDuration`, set-next-date | `Book.review` | |
 | 011 | Several values in one field | `Multi`, `MultiInput` | `Book.themes` | |

--- a/demo/smoke.mjs
+++ b/demo/smoke.mjs
@@ -64,6 +64,26 @@ async function teardown() {
 	if (quitTheirs) relaunchObsidian();
 }
 
+/**
+ * Waits for the plugin to be loaded. A freshly staged vault opens its workspace
+ * before its community plugins, and Obsidian may hold them behind a trust prompt —
+ * so this is a real wait, not a courtesy sleep, and its failure is actionable.
+ */
+async function waitForPlugin(stage, { timeout = 25000 } = {}) {
+	const start = Date.now();
+	while (Date.now() - start < timeout) {
+		const state = await stage.appPage
+			.evaluate(() => ({
+				loaded: !!window.app.plugins.plugins.fileclass,
+				enabled: [...(window.app.plugins.enabledPlugins ?? [])],
+			}))
+			.catch(() => ({ loaded: false, enabled: [] }));
+		if (state.loaded) return true;
+		await sleep(500);
+	}
+	return false;
+}
+
 /** Everything the app can tell us about the staged vault, in one round trip. */
 async function inspect(stage) {
 	// The settings pane is DOM-only, so it has to be open to read its labels.
@@ -89,6 +109,7 @@ async function inspect(stage) {
 	const facts = await stage.appPage.evaluate(() => {
 		const app = window.app;
 		const p = app.plugins.plugins.fileclass;
+		if (!p) return { version: null, basesAvailable: false, classNames: [], commands: [], notes: [] };
 		const commands = Object.values(app.commands.commands)
 			.filter((c) => c.id.startsWith("fileclass:"))
 			.map((c) => c.name.replace(/^Fileclass:\s*/, ""));
@@ -190,7 +211,20 @@ async function main() {
 
 	const stage = await connect(port);
 	if (!attach) await stage.waitForVault(vaultPath);
-	await sleep(600); // let the index settle after load
+	if (!(await waitForPlugin(stage))) {
+		console.log(
+			warn("\nFileclass isn't loaded in that vault.") +
+				"\nObsidian is most likely asking to trust it (community plugins stay off until you\n" +
+				"do), or Restricted mode is on. Accept it in the window, then press Enter here."
+		);
+		const rl = createInterface({ input: process.stdin, output: process.stdout });
+		await rl.question("");
+		rl.close();
+		if (!(await waitForPlugin(stage, { timeout: 8000 }))) {
+			throw new Error("Fileclass still isn't loaded — nothing to check against.");
+		}
+	}
+	await sleep(800); // let the index settle once the plugin is up
 	report(await inspect(stage));
 	stage.disconnect();
 

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -193,6 +193,14 @@ must **save the change in the fileClass settings** for the picker to use it.
 
 ## Date fields (Date / DateTime / Time)
 
+{{< video "008" >}}
+
+Three types for three questions: `Date` is a day, `DateTime` a **point in time** (a
+day and a clock in one value), `Time` a **time of day** with no day attached — the
+hour a door opens, every session. Each is stored in its own native form —
+`YYYY-MM-DD`, `YYYY-MM-DD[T]HH:mm`, `HH:mm` — and has its own default write format in
+the settings.
+
 Editing a date opens a **native picker** (calendar / clock) with **Today** and
 **Clear** buttons, plus a **link toggle**:
 

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -36,3 +36,7 @@ other. Captions are English; YouTube translates them into your language.
 ## Date: the format you store
 
 {{< video "007" >}}
+
+## DateTime and Time
+
+{{< video "008" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -75,5 +75,16 @@
     "durationSeconds": 174,
     "recordedWith": "0.1.1",
     "privacyStatus": "public"
+  },
+  "008": {
+    "id": "bInkg1jLOmM",
+    "url": "https://www.youtube.com/watch?v=bInkg1jLOmM",
+    "title": "Fileclass #008 · DateTime and Time",
+    "subject": "DateTime and Time",
+    "scenario": "008_datetime_and_time",
+    "doc": "fields/#date-fields-date--datetime--time",
+    "durationSeconds": 137,
+    "recordedWith": "0.1.1",
+    "privacyStatus": "public"
   }
 }


### PR DESCRIPTION
Take 008: https://www.youtube.com/watch?v=bInkg1jLOmM (2:17)

## The take

Its subject is the **distinction**, not the picker — 007 already showed that. A
`DateTime` is a point in time, a date and a clock in one value; a `Time` is a time of
day with no day attached, the hour the doors open *every* session. The take introduces
the `Activity` class on a reading-group note whose two time facts sit buried in a
sentence.

It deliberately types nothing but names — three typing steps — which is the typing-tax
rule from #68 applied on purpose. 60.3 s of narration landed a 2:17 video, against
007's 2:54 for the same narration budget.

`fields.md` now opens its Date section by naming what separates the three types, with
their native forms, rather than treating them as one thing.

## smoke.mjs, first real use, first failure

It read the plugin 600 ms after the vault opened — before Obsidian had loaded its
community plugins — and reported a puppeteer stack trace at the operator. It now:

- **waits** for the plugin (up to 25 s), which is what a freshly staged vault needs;
- when it never comes, says what to do: Obsidian holds community plugins behind a
  trust prompt on a vault it has never seen, so accept it and press Enter to retry;
- reads the facts defensively, so a missing plugin can't throw at all.

Worth noting the report earned its keep on the very same run: it showed Tolkien's book
still missing `ownership` and `published` — the continuity debt 006 and 007 left by
only ever touching Dune. That's the kind of thing reading a script can't reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
