### PR TITLE
refactor: resolve getFileClassFile from index with fallback (#72)

### DIFF
--- a/src/schema/fileclassIndex.ts
+++ b/src/schema/fileclassIndex.ts
@@ -32,6 +32,10 @@ export const INDEXED_EVENT = "fileclass:indexed";
 export class FileclassIndex extends Events {
 	private byName = new Map<string, ParsedFileClass>();
 	private nameByPath = new Map<string, string>();
+
+	// 1. Keep a pathByName reverse map
+  private pathByName: Map<string, string> = new Map<string, string>();
+
 	private ancestorsByName = new Map<string, string[]>();
 	private fieldsByName = new Map<string, Field[]>();
 	private tagBindings = new Map<string, string>();
@@ -70,6 +74,10 @@ export class FileclassIndex extends Events {
 	private clear(): void {
 		this.byName.clear();
 		this.nameByPath.clear();
+
+		// 3. Clear the pathByName map as well
+    this.pathByName.clear();
+
 		this.ancestorsByName.clear();
 		this.fieldsByName.clear();
 		this.tagBindings.clear();
@@ -85,6 +93,10 @@ export class FileclassIndex extends Events {
 		const parsed = parseFileClass(name, frontmatter);
 		this.byName.set(name, parsed);
 		this.nameByPath.set(file.path, name);
+
+		// 2. When a fileClass note is indexed, update pathByName as well
+    this.pathByName.set(name, file.path);
+
 		if (parsed.errors.length) this.errors.push(...parsed.errors);
 	}
 
@@ -202,8 +214,18 @@ export class FileclassIndex extends Events {
 	}
 
 	/** The Markdown note backing a fileClass (`<classFilesPath><name>.md`). */
-	getFileClassFile(name: string): TFile | null {
-		const folder = this.host.settings.classFilesPath;
+  getFileClassFile(name: string): TFile | null {
+
+    // 4. Look up for path in pathByName first
+    const path = this.pathByName.get(name);
+    if (path) {
+      const file = this.app.vault.getFileByPath(path);
+      if (file instanceof File) return file;
+    }
+
+    // Not indexed yet (class created before the debounced rebuild fired).
+    // fall back to a direct lookup.
+    const folder = this.host.settings.classFilesPath;
 		if (!folder) return null;
 		const file = this.app.vault.getFileByPath(`${folder}${name}.md`);
 		return file instanceof TFile ? file : null;

--- a/src/schema/fileclassIndex.ts
+++ b/src/schema/fileclassIndex.ts
@@ -32,7 +32,8 @@ export const INDEXED_EVENT = "fileclass:indexed";
 export class FileclassIndex extends Events {
 	private byName = new Map<string, ParsedFileClass>();
 	private nameByPath = new Map<string, string>();
-  	private pathByName: Map<string, string> = new Map<string, string>(); // Invariant: pathByName must stay in step with nameByPath across clear() and rebuilds
+	/** Reverse of `nameByPath`; `rebuild()` clears and refills both together. */
+	private pathByName = new Map<string, string>();
 	private ancestorsByName = new Map<string, string[]>();
 	private fieldsByName = new Map<string, Field[]>();
 	private tagBindings = new Map<string, string>();
@@ -87,7 +88,7 @@ export class FileclassIndex extends Events {
 		const parsed = parseFileClass(name, frontmatter);
 		this.byName.set(name, parsed);
 		this.nameByPath.set(file.path, name);
-    	this.pathByName.set(name, file.path);
+		this.pathByName.set(name, file.path);
 		if (parsed.errors.length) this.errors.push(...parsed.errors);
 	}
 
@@ -205,11 +206,11 @@ export class FileclassIndex extends Events {
 	}
 
 	/** The Markdown note backing a fileClass (`<classFilesPath><name>.md`). */
-  	getFileClassFile(name: string): TFile | null {
+	getFileClassFile(name: string): TFile | null {
 		const path = this.pathByName.get(name);
 		if (path) {
-		  const file = this.app.vault.getFileByPath(path);
-		  if (file instanceof TFile) return file;
+			const file = this.app.vault.getFileByPath(path);
+			if (file instanceof TFile) return file;
 		}
 		// Not indexed yet (class created before the debounced rebuild fired).
 		const folder = this.host.settings.classFilesPath;

--- a/src/schema/fileclassIndex.ts
+++ b/src/schema/fileclassIndex.ts
@@ -32,7 +32,7 @@ export const INDEXED_EVENT = "fileclass:indexed";
 export class FileclassIndex extends Events {
 	private byName = new Map<string, ParsedFileClass>();
 	private nameByPath = new Map<string, string>();
-  	private pathByName: Map<string, string> = new Map<string, string>();
+  	private pathByName: Map<string, string> = new Map<string, string>(); // Invariant: pathByName must stay in step with nameByPath across clear() and rebuilds
 	private ancestorsByName = new Map<string, string[]>();
 	private fieldsByName = new Map<string, Field[]>();
 	private tagBindings = new Map<string, string>();

--- a/src/schema/fileclassIndex.ts
+++ b/src/schema/fileclassIndex.ts
@@ -32,10 +32,7 @@ export const INDEXED_EVENT = "fileclass:indexed";
 export class FileclassIndex extends Events {
 	private byName = new Map<string, ParsedFileClass>();
 	private nameByPath = new Map<string, string>();
-
-	// 1. Keep a pathByName reverse map
-  private pathByName: Map<string, string> = new Map<string, string>();
-
+  	private pathByName: Map<string, string> = new Map<string, string>();
 	private ancestorsByName = new Map<string, string[]>();
 	private fieldsByName = new Map<string, Field[]>();
 	private tagBindings = new Map<string, string>();
@@ -74,10 +71,7 @@ export class FileclassIndex extends Events {
 	private clear(): void {
 		this.byName.clear();
 		this.nameByPath.clear();
-
-		// 3. Clear the pathByName map as well
-    this.pathByName.clear();
-
+		this.pathByName.clear();
 		this.ancestorsByName.clear();
 		this.fieldsByName.clear();
 		this.tagBindings.clear();
@@ -93,10 +87,7 @@ export class FileclassIndex extends Events {
 		const parsed = parseFileClass(name, frontmatter);
 		this.byName.set(name, parsed);
 		this.nameByPath.set(file.path, name);
-
-		// 2. When a fileClass note is indexed, update pathByName as well
-    this.pathByName.set(name, file.path);
-
+    	this.pathByName.set(name, file.path);
 		if (parsed.errors.length) this.errors.push(...parsed.errors);
 	}
 
@@ -214,18 +205,14 @@ export class FileclassIndex extends Events {
 	}
 
 	/** The Markdown note backing a fileClass (`<classFilesPath><name>.md`). */
-  getFileClassFile(name: string): TFile | null {
-
-    // 4. Look up for path in pathByName first
-    const path = this.pathByName.get(name);
-    if (path) {
-      const file = this.app.vault.getFileByPath(path);
-      if (file instanceof File) return file;
-    }
-
-    // Not indexed yet (class created before the debounced rebuild fired).
-    // fall back to a direct lookup.
-    const folder = this.host.settings.classFilesPath;
+  	getFileClassFile(name: string): TFile | null {
+		const path = this.pathByName.get(name);
+		if (path) {
+		  const file = this.app.vault.getFileByPath(path);
+		  if (file instanceof TFile) return file;
+		}
+		// Not indexed yet (class created before the debounced rebuild fired).
+		const folder = this.host.settings.classFilesPath;
 		if (!folder) return null;
 		const file = this.app.vault.getFileByPath(`${folder}${name}.md`);
 		return file instanceof TFile ? file : null;

--- a/src/schema/fileclassIndex.ts
+++ b/src/schema/fileclassIndex.ts
@@ -205,7 +205,7 @@ export class FileclassIndex extends Events {
 		return this.nameByPath.get(path);
 	}
 
-	/** The Markdown note backing a fileClass (`<classFilesPath><name>.md`). */
+	/** The Markdown note backing a fileClass, from the index (falling back to the conventional path) */
 	getFileClassFile(name: string): TFile | null {
 		const path = this.pathByName.get(name);
 		if (path) {


### PR DESCRIPTION
## Description
This PR refactor `FileclassIndex.getFileClassFile()` to query the index reverse map rather than manually reconstructing file paths from settings.

Resolves #72

---

## Problem & Motivation
Previously, `getFileClassFile(name: string)` reconstructed the file path directly using `this.host.settings.classFilesPath` (`${folder}${name}.md`). 

This approach had two drawbacks:
1.  `FileclassIndex` already scans and maintains `nameByPath` (`file.path` → `fileClass name`). Rebuilding the path bypassed the existing index.
2. If fileClass discovery rules or extensions change, `getFileClassFile()` silently returned `null` without error, leaving schema editors, modals, and base file generators inactive.

---

## Changes Made
- Introduced a `pathByName: Map<string, string>` map in `FileclassIndex`.
- Updated `indexFileClassNote()` to populate `pathByName` alongside `nameByPath`.
- Updated `clear()` to reset `pathByName` during index resets.
- Refactored `getFileClassFile(name: string)` to:
  1. Query `this.pathByName.get(name)` first.
  2. Fall back to direct path construction (`<classFilesPath><name>.md`) for unindexed or newly created fileClasses prior to debounced index rebuilds.

---

## Testing & Verification

### 1. Build Verification
- Verified clean TypeScript compilation and bundling via `npm run build`.

### 2. Manual Testing in Obsidian
- Created a clean test vault with a custom build of the plugin.
- Created a test fileClass note at `Fileclasses/Task.md`.
- Opened the **FileClass Schema Modal** (`Schema — Task`) and verified that `getFileClassFile("Task")` successfully resolves the `TFile` via the index lookup without errors or missing fields.

### Result
<img width="984" height="514" alt="verify" src="https://github.com/user-attachments/assets/1169150f-a4c8-4a3b-a7f5-99946895eb9a" />
