### PR TITLE
docs(demo): take 010 — CycleDuration, and the trust prompt in the way

### DIFF
--- a/demo/010_cycle_duration/demo-vault/.obsidian/workspace.json
+++ b/demo/010_cycle_duration/demo-vault/.obsidian/workspace.json
@@ -1,0 +1,60 @@
+{
+  "main": {
+    "id": "demo-main",
+    "type": "split",
+    "direction": "vertical",
+    "children": [
+      {
+        "id": "demo-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-note",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": { "file": "Atomic Habits.md", "mode": "source", "source": false }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "left": {
+    "id": "demo-left",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "children": [
+      {
+        "id": "demo-left-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-explorer",
+            "type": "leaf",
+            "state": { "type": "file-explorer", "state": { "sortOrder": "alphabetical" } }
+          }
+        ]
+      }
+    ]
+  },
+  "right": {
+    "id": "demo-right",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "collapsed": true,
+    "children": [
+      {
+        "id": "demo-right-tabs",
+        "type": "tabs",
+        "children": [
+          { "id": "demo-backlink", "type": "leaf", "state": { "type": "backlink", "state": {} } }
+        ]
+      }
+    ]
+  },
+  "active": "demo-note",
+  "lastOpenFiles": ["Atomic Habits.md", "Kind of Blue.md", "Dune.md"]
+}

--- a/demo/010_cycle_duration/demo-vault/Atomic Habits.md
+++ b/demo/010_cycle_duration/demo-vault/Atomic Habits.md
@@ -1,0 +1,13 @@
+---
+fileClass: Book
+publisher: Avery
+pages: 320
+genre: 
+read: true
+ownership: Owned
+published: 2018-10-16
+---
+The one about systems over goals, and about making the good thing the easy thing.
+
+Worth coming back to twice a year: the habits it describes are easy to nod at and
+easy to drop.

--- a/demo/010_cycle_duration/demo-vault/Classes/Activity.md
+++ b/demo/010_cycle_duration/demo-vault/Classes/Activity.md
@@ -1,0 +1,13 @@
+---
+fields:
+  - name: starts
+    id: sTr7ts
+    type: DateTime
+    options: {}
+    path: ""
+  - name: doors
+    id: dOr4ms
+    type: Time
+    options: {}
+    path: ""
+---

--- a/demo/010_cycle_duration/demo-vault/Classes/Album.md
+++ b/demo/010_cycle_duration/demo-vault/Classes/Album.md
@@ -1,0 +1,8 @@
+---
+fields:
+  - name: length
+    id: lNg3th
+    type: Duration
+    options: {}
+    path: ""
+---

--- a/demo/010_cycle_duration/demo-vault/Classes/Book.md
+++ b/demo/010_cycle_duration/demo-vault/Classes/Book.md
@@ -1,0 +1,45 @@
+---
+fields:
+  - name: publisher
+    id: kQ7mzT
+    type: Input
+    options: {}
+    path: ""
+  - name: pages
+    id: pG42nx
+    type: Number
+    options:
+      min: 1
+      max: 5000
+    path: ""
+  - name: genre
+    id: gNr8wc
+    type: Select
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Science fiction
+        "2": Fantasy
+        "3": Comics
+    path: ""
+  - name: read
+    id: rD5tqB
+    type: Boolean
+    options: {}
+    path: ""
+  - name: ownership
+    id: oWn5hp
+    type: Cycle
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Wanted
+        "2": Owned
+        "3": Lent out
+    path: ""
+  - name: published
+    id: pBl9dt
+    type: Date
+    options: {}
+    path: ""
+---

--- a/demo/010_cycle_duration/demo-vault/Dune.md
+++ b/demo/010_cycle_duration/demo-vault/Dune.md
@@ -1,0 +1,14 @@
+---
+fileClass: Book
+publisher: Chilton Books
+pages: 412
+genre: Science fiction
+read: true
+ownership: Owned
+published: 1965-08-01
+---
+Frank Herbert spent five years on desert ecology and the politics of water
+before Chilton Books — until then a publisher of car repair manuals — took the
+manuscript, in 1965.
+
+412 pages in that first edition, and not one of them wasted.

--- a/demo/010_cycle_duration/demo-vault/Kind of Blue.md
+++ b/demo/010_cycle_duration/demo-vault/Kind of Blue.md
@@ -1,0 +1,8 @@
+---
+fileClass: Album
+length: PT45M44S
+---
+Recorded in two sessions at Columbia's 30th Street Studio, March and April 1959,
+with Bill Evans at the piano on every track but one.
+
+Forty-five minutes and forty-four seconds that changed what a quintet could be.

--- a/demo/010_cycle_duration/demo-vault/Reading group.md
+++ b/demo/010_cycle_duration/demo-vault/Reading group.md
@@ -1,0 +1,9 @@
+---
+fileClass: Activity
+starts: 2026-09-10T19:00
+doors: "18:30"
+---
+The reading group meets at the library on the second Thursday of the month.
+Next session: 10 September 2026, 7 pm — doors at 6:30.
+
+Dune this time; bring the Fremen chapters.

--- a/demo/010_cycle_duration/demo-vault/The Lord of the Rings.md
+++ b/demo/010_cycle_duration/demo-vault/The Lord of the Rings.md
@@ -1,0 +1,11 @@
+---
+fileClass: Book
+publisher: ""
+pages: ""
+genre: Fantasy
+read: false
+---
+Allen & Unwin brought it out in three volumes from 1954, against Tolkien's wish
+for a single book. Mine is the 1991 paperback set, spines long gone.
+
+1178 pages across the three, appendices included.

--- a/demo/010_cycle_duration/demo-vault/Tintin in Tibet.md
+++ b/demo/010_cycle_duration/demo-vault/Tintin in Tibet.md
@@ -1,0 +1,4 @@
+Hergé's own favourite, drawn in the middle of a breakdown, and the only album
+with no villain in it. Casterman, 1960.
+
+62 pages, like every album in the series.

--- a/demo/010_cycle_duration/scenario.yaml
+++ b/demo/010_cycle_duration/scenario.yaml
@@ -1,0 +1,37 @@
+# Narration for take 010 — see ../SCENARIO.md for the format.
+# Starts where 009 ended: Album exists with its length field, Kind of Blue is
+# filled. Scope: CycleDuration — a sequence of spans rather than one, its presets,
+# and the fact that the order *is* the schedule. The date that walks the sequence
+# is 010b: rotation is the subtlest behaviour in the plugin (one click writes a
+# date and mutates a list), and it needs room to be seen twice.
+title: "Fileclass — CycleDuration: a sequence, not a duration"
+description: "Schedule a re-read by a sequence of intervals you compose yourself."
+doc: "fields/#an-interval-sequence-cycleduration" # deep link used in the description
+tags: "cycleduration, spaced repetition, interval sequence"
+vault_name: "Demo"
+plugin: true
+settings:
+  classFilesPath: "Classes/"
+  fileClassAlias: "fileClass"
+initial_pause: 1500
+default_pause: 900
+
+steps:
+  - title: "Atomic Habits is worth re-reading — on a schedule, not on a whim"
+    pause: 1800
+  - title: "That needs a sequence of intervals, not a single duration"
+    pause: 1800
+  - title: "Add a field named next interval, type CycleDuration"
+    pause: 1400
+  - title: "Its options hold the spans this class reuses: 90, 180 and 360 days"
+    pause: 1800
+  - title: "Presets are the class's vocabulary; the sequence is this note's choice"
+    pause: 1800
+  - title: "Save, then open the field: each preset adds itself with one click"
+    pause: 1800
+  - title: "The order is the schedule — move an item and you've changed it"
+    pause: 1800
+  - title: "Stored as a list of ISO spans, in that order"
+    pause: 1600
+  - title: "A sequence alone does nothing — next, a date that walks it 🎉"
+    pause: 2200

--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -53,7 +53,8 @@ thread, and a tight smoke test of that type's input path.
 | 007 | Date — the format you store | `Date`, picker, three-level write format, format check | `Book.published` | ✅ [published](https://www.youtube.com/watch?v=1c2a1usAPRU) |
 | 008 | DateTime and Time | `DateTime`, `Time` (a point in time vs a time of day) | `Activity` class, `Reading group` note | ✅ [published](https://www.youtube.com/watch?v=bInkg1jLOmM) |
 | 009 | Duration | `Duration` (words, spinners, ISO on disk) | `Album` class, `Kind of Blue` note | ✅ [published](https://www.youtube.com/watch?v=G3mUhJ1Ywuc) |
-| 010 | Cycling an interval, and the next date | `CycleDuration`, `Duration` presets, set-next-date | `Book.review` | |
+| 010 | CycleDuration: a sequence, not a duration | `CycleDuration`, `Duration` presets | `Atomic Habits` note, `Book.next interval` | ✅ [published](https://www.youtube.com/watch?v=lhrJ2a5pFRY) |
+| 010b | Set next date | the `Next interval field` option, and the rotation it drives | `Book.review` | |
 | 011 | Several values in one field | `Multi`, `MultiInput` | `Book.themes` | |
 
 ## Arc 3 — fields that point at notes
@@ -115,4 +116,5 @@ thread, and a tight smoke test of that type's input path.
 | 038 | Groups on a canvas as data | `CanvasGroup`, `CanvasGroupLink` | — | |
 | 039 | The settings, one pass | behaviour toggles, indicators, defaults | — | |
 
-**39 takes, roughly 45 minutes of finished video.**
+**41 takes** (39 numbered, plus `010b` and `016b` — facets that earned their own
+take), roughly 50 minutes of finished video.

--- a/demo/SCENARIO.md
+++ b/demo/SCENARIO.md
@@ -159,6 +159,7 @@ many steps ask the operator to **type**.
 | 007  | 60.8 s    | 2:54           | ×2.86 | 5 |
 | 008  | 60.3 s    | 2:17           | ×2.27 | 3 |
 | 009  | 52.7 s    | 1:38           | ×1.86 | 3 |
+| 010  | 49.5 s    | 1:42           | ×2.07 | 3 |
 
 Click-driven takes land between ×1.6 and ×2.3 of their narration; take 007 respected
 the narration budget to the second and still ran a minute longer, because it was the

--- a/demo/lib/trust.mjs
+++ b/demo/lib/trust.mjs
@@ -1,0 +1,69 @@
+/*
+ * Getting past "Do you trust the author of this vault?".
+ *
+ * Obsidian holds a new vault's community plugins behind that dialog, and remembers
+ * the answer in localStorage under `enable-plugin-<vault id>` — an id derived from
+ * the vault's path. Every take stages its own path, so every take meets the dialog
+ * once: the plugin never loads, a smoke test has nothing to inspect, and a take
+ * would open on camera with a modal in front of it.
+ *
+ * Clicking it is safe here in a way it would never be in general: the vault was
+ * staged by this tooling seconds ago and the only plugin in it is the one being
+ * demonstrated, copied from this repo's own build.
+ */
+
+/** True when a page is showing the trust dialog. */
+const TRUST_TEXT = /trust the author of this vault/i;
+const TRUST_BUTTON = /trust author/i;
+
+/**
+ * Accepts the trust dialog if it's up, in whichever window shows it.
+ * @returns true when a dialog was accepted, false when there was none.
+ */
+export async function acceptVaultTrust(stage) {
+	for (const page of stage.pages) {
+		const clicked = await page
+			.evaluate(
+				(textSrc, buttonSrc) => {
+					const text = new RegExp(textSrc, "i");
+					const button = new RegExp(buttonSrc, "i");
+					for (const modal of document.querySelectorAll(".modal-container")) {
+						if (!text.test(modal.textContent ?? "")) continue;
+						const accept = [...modal.querySelectorAll("button")].find((b) =>
+							button.test(b.textContent ?? "")
+						);
+						if (accept) {
+							accept.click();
+							return true;
+						}
+					}
+					return false;
+				},
+				TRUST_TEXT.source,
+				TRUST_BUTTON.source
+			)
+			.catch(() => false);
+		if (clicked) return true;
+	}
+	return false;
+}
+
+/**
+ * Waits for the plugin to be loaded, accepting the trust dialog as soon as it
+ * appears. Both are the same wait from the caller's point of view: "is the plugin
+ * there yet, and is anything obvious in the way?"
+ */
+export async function waitForPlugin(stage, { timeout = 25000, poll = 500 } = {}) {
+	const start = Date.now();
+	let trusted = false;
+	while (Date.now() - start < timeout) {
+		const loaded = await stage.appPage
+			.evaluate(() => !!window.app.plugins.plugins.fileclass)
+			.catch(() => false);
+		if (loaded) return { loaded: true, trusted };
+		await stage.refresh(); // the dialog may live in its own window
+		if (await acceptVaultTrust(stage)) trusted = true;
+		await new Promise((r) => setTimeout(r, poll));
+	}
+	return { loaded: false, trusted };
+}

--- a/demo/record.mjs
+++ b/demo/record.mjs
@@ -39,6 +39,7 @@ import {
 	writeTakeLog,
 } from "./lib/stage.mjs";
 import { CUE_LABEL, connect } from "./lib/subtitles.mjs";
+import { waitForPlugin } from "./lib/trust.mjs";
 import { DEFAULT_RATE, resolveVoice, speak, spokenText } from "./lib/voice.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -168,6 +169,11 @@ async function main() {
 		console.log(dim(`Attached to "${v?.name}" (${v?.path})`));
 	} else {
 		await stage.waitForVault(vaultPath);
+		// A staged vault is new to Obsidian, which holds its plugins behind a trust
+		// dialog — dismissed here so the take doesn't open with a modal in frame.
+		const { loaded, trusted } = await waitForPlugin(stage);
+		if (trusted) console.log(dim("Accepted this vault's trust prompt"));
+		if (!loaded) console.warn(dim("Warning: Fileclass isn't loaded in that vault."));
 		console.log(dim(`Opened   "${scenario.vaultName}"`));
 	}
 

--- a/demo/smoke.mjs
+++ b/demo/smoke.mjs
@@ -34,6 +34,7 @@ import {
 	wipeVault,
 } from "./lib/stage.mjs";
 import { fieldTypesFromSource, scanScript } from "./lib/scriptScan.mjs";
+import { waitForPlugin } from "./lib/trust.mjs";
 import { connect } from "./lib/subtitles.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -62,26 +63,6 @@ async function teardown() {
 	registry?.restore();
 	if (staged) wipeVault(scenario);
 	if (quitTheirs) relaunchObsidian();
-}
-
-/**
- * Waits for the plugin to be loaded. A freshly staged vault opens its workspace
- * before its community plugins, and Obsidian may hold them behind a trust prompt —
- * so this is a real wait, not a courtesy sleep, and its failure is actionable.
- */
-async function waitForPlugin(stage, { timeout = 25000 } = {}) {
-	const start = Date.now();
-	while (Date.now() - start < timeout) {
-		const state = await stage.appPage
-			.evaluate(() => ({
-				loaded: !!window.app.plugins.plugins.fileclass,
-				enabled: [...(window.app.plugins.enabledPlugins ?? [])],
-			}))
-			.catch(() => ({ loaded: false, enabled: [] }));
-		if (state.loaded) return true;
-		await sleep(500);
-	}
-	return false;
 }
 
 /** Everything the app can tell us about the staged vault, in one round trip. */
@@ -211,18 +192,13 @@ async function main() {
 
 	const stage = await connect(port);
 	if (!attach) await stage.waitForVault(vaultPath);
-	if (!(await waitForPlugin(stage))) {
-		console.log(
-			warn("\nFileclass isn't loaded in that vault.") +
-				"\nObsidian is most likely asking to trust it (community plugins stay off until you\n" +
-				"do), or Restricted mode is on. Accept it in the window, then press Enter here."
+	const { loaded, trusted } = await waitForPlugin(stage);
+	if (trusted) console.log(dim("Accepted this vault's trust prompt (staged vaults are new to Obsidian)"));
+	if (!loaded) {
+		throw new Error(
+			"Fileclass never loaded in that vault — Restricted mode may be on for it, " +
+				"or the plugin build is missing (run `npm run build`)."
 		);
-		const rl = createInterface({ input: process.stdin, output: process.stdout });
-		await rl.question("");
-		rl.close();
-		if (!(await waitForPlugin(stage, { timeout: 8000 }))) {
-			throw new Error("Fileclass still isn't loaded — nothing to check against.");
-		}
 	}
 	await sleep(800); // let the index settle once the plugin is up
 	report(await inspect(stage));

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -298,7 +298,15 @@ button on a `Duration` field, and chips you tap to append on a `CycleDuration`
 list (you can still reorder, add a custom one, or repeat a preset). Presets are
 a convenience — values are still stored per note.
 
-`CycleDuration` stores an **ordered list** of durations — an *interval sequence*.
+### An interval sequence (`CycleDuration`)
+
+{{< video "010" >}}
+
+`CycleDuration` stores an **ordered list** of durations — an *interval sequence*. The
+order is the schedule: it is what a linked date field walks through, one interval per
+click. Its **presets** are the class's vocabulary of spans (say 90, 180 and 360 days
+for a re-read cycle); the sequence itself is each note's own composition — two of
+them, all three, or the same one twice.
 
 ### Set next date (spaced repetition)
 

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -44,3 +44,7 @@ other. Captions are English; YouTube translates them into your language.
 ## Duration
 
 {{< video "009" >}}
+
+## CycleDuration: a sequence, not a duration
+
+{{< video "010" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -97,5 +97,16 @@
     "durationSeconds": 98,
     "recordedWith": "0.1.1",
     "privacyStatus": "public"
+  },
+  "010": {
+    "id": "lhrJ2a5pFRY",
+    "url": "https://www.youtube.com/watch?v=lhrJ2a5pFRY",
+    "title": "Fileclass #010 · CycleDuration: a sequence, not a duration",
+    "subject": "CycleDuration: a sequence, not a duration",
+    "scenario": "010_cycle_duration",
+    "doc": "fields/#an-interval-sequence-cycleduration",
+    "durationSeconds": 102,
+    "recordedWith": "0.1.1",
+    "privacyStatus": "public"
   }
 }


### PR DESCRIPTION
Take 010: https://www.youtube.com/watch?v=lhrJ2a5pFRY (1:42)

## The take

Its subject is the **sequence**: a list of spans whose *order is the schedule*, built
from presets that are the class's vocabulary while the sequence stays each note's own
composition — two of them, all three, or the same one twice.

The date that walks it is **010b**. Rotation is the subtlest behaviour in the plugin —
one click writes a date *and* mutates a list — and it needs room to be seen twice,
which the tail of a three-minute take wouldn't have given it. That's what the letter
suffix from #68 is for.

The example is a method book, *Atomic Habits* on a 90 / 180 / 360-day re-read cycle,
because re-reading *Dune* every three months fools nobody. Its `genre` stays **empty on
purpose**: the Select list holds Science fiction, Fantasy and Comics, none of which
covers non-fiction. That's a real modelling gap, left visible for a later take rather
than patched off-camera.

`fields.md` gains a heading of its own for the interval sequence, so 009 and 010 don't
compete for one card slot.

## The smoke test earned its keep, by failing

Obsidian asks **"Do you trust the author of this vault?"** for any vault it has never
seen, and holds the community plugins until you answer. So the plugin never loaded, the
smoke test had nothing to inspect, and it hung waiting on stdin.

The answer lives in `localStorage` under `enable-plugin-<vault id>` — an id derived from
the vault's **path**, which means every take meets that dialog once. Until now you
clicked it without thinking before cueing; it could equally have appeared on camera.

`lib/trust.mjs` accepts it, in `smoke.mjs` and in `record.mjs` both, so a take can't
open with a modal in frame. Clicking it is safe in exactly this context and no other:
the vault was staged seconds earlier by this tooling, and its only plugin is the one
being demonstrated, copied from this repo's build.

Verified on a never-trusted path (`FILECLASS_DEMO_HOME=…`), where the dialog does
appear and gets accepted:

```
Staged   /private/tmp/…/010_cycle_duration/Demo (plugin 0.1.1)
Accepted this vault's trust prompt (staged vaults are new to Obsidian)
plugin 0.1.1 · Bases available · classes: Book, Album, Activity
```

The error path is simpler for it: the "accept the prompt then press Enter" fallback is
gone, replaced by a wait that clicks, and a message that names what's left (Restricted
mode, or a missing build).

## Budget

| take | narration | video | ratio | typing |
| ---- | --------- | ----- | ----- | ------ |
| 009  | 52.7 s    | 1:38  | ×1.86 | 3 |
| 010  | 49.5 s    | 1:42  | ×2.07 | 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
