### PR TITLE
docs(demo): take 012 — a field that points at a note

### DIFF
--- a/demo/012_link_a_note/demo-vault/.obsidian/workspace.json
+++ b/demo/012_link_a_note/demo-vault/.obsidian/workspace.json
@@ -1,0 +1,80 @@
+{
+  "main": {
+    "id": "demo-main",
+    "type": "split",
+    "direction": "vertical",
+    "children": [
+      {
+        "id": "demo-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-note",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "Dune.md",
+                "mode": "source",
+                "source": false
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "left": {
+    "id": "demo-left",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "children": [
+      {
+        "id": "demo-left-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-explorer",
+            "type": "leaf",
+            "state": {
+              "type": "file-explorer",
+              "state": {
+                "sortOrder": "alphabetical"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "right": {
+    "id": "demo-right",
+    "type": "split",
+    "direction": "horizontal",
+    "width": 300,
+    "collapsed": true,
+    "children": [
+      {
+        "id": "demo-right-tabs",
+        "type": "tabs",
+        "children": [
+          {
+            "id": "demo-backlink",
+            "type": "leaf",
+            "state": {
+              "type": "backlink",
+              "state": {}
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "active": "demo-note",
+  "lastOpenFiles": [
+    "Atomic Habits.md",
+    "Kind of Blue.md",
+    "Dune.md"
+  ]
+}

--- a/demo/012_link_a_note/demo-vault/Atomic Habits.md
+++ b/demo/012_link_a_note/demo-vault/Atomic Habits.md
@@ -1,0 +1,18 @@
+---
+fileClass: Book
+publisher: Avery
+pages: 320
+genre: 
+read: true
+ownership: Owned
+published: 2018-10-16
+review: 2028-04-21
+next interval:
+  - P90D
+  - P180D
+  - P360D
+---
+The one about systems over goals, and about making the good thing the easy thing.
+
+Worth coming back to twice a year: the habits it describes are easy to nod at and
+easy to drop.

--- a/demo/012_link_a_note/demo-vault/Authors.base
+++ b/demo/012_link_a_note/demo-vault/Authors.base
@@ -1,0 +1,13 @@
+views:
+  - type: table
+    name: All authors
+    filters:
+      and:
+        - fileClass == "Author"
+    sort:
+      - property: born
+        direction: ASC
+    order:
+      - file.name
+      - born
+      - nationality

--- a/demo/012_link_a_note/demo-vault/Classes/Activity.md
+++ b/demo/012_link_a_note/demo-vault/Classes/Activity.md
@@ -1,0 +1,13 @@
+---
+fields:
+  - name: starts
+    id: sTr7ts
+    type: DateTime
+    options: {}
+    path: ""
+  - name: doors
+    id: dOr4ms
+    type: Time
+    options: {}
+    path: ""
+---

--- a/demo/012_link_a_note/demo-vault/Classes/Album.md
+++ b/demo/012_link_a_note/demo-vault/Classes/Album.md
@@ -1,0 +1,8 @@
+---
+fields:
+  - name: length
+    id: lNg3th
+    type: Duration
+    options: {}
+    path: ""
+---

--- a/demo/012_link_a_note/demo-vault/Classes/Author.md
+++ b/demo/012_link_a_note/demo-vault/Classes/Author.md
@@ -1,0 +1,13 @@
+---
+fields:
+  - name: born
+    id: bR1dte
+    type: Date
+    options: {}
+    path: ""
+  - name: nationality
+    id: nT2ion
+    type: Input
+    options: {}
+    path: ""
+---

--- a/demo/012_link_a_note/demo-vault/Classes/Book.md
+++ b/demo/012_link_a_note/demo-vault/Classes/Book.md
@@ -1,0 +1,75 @@
+---
+fields:
+  - name: publisher
+    id: kQ7mzT
+    type: Input
+    options: {}
+    path: ""
+  - name: pages
+    id: pG42nx
+    type: Number
+    options:
+      min: 1
+      max: 5000
+    path: ""
+  - name: genre
+    id: gNr8wc
+    type: Select
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Science fiction
+        "2": Fantasy
+        "3": Comics
+    path: ""
+  - name: read
+    id: rD5tqB
+    type: Boolean
+    options: {}
+    path: ""
+  - name: ownership
+    id: oWn5hp
+    type: Cycle
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Wanted
+        "2": Owned
+        "3": Lent out
+    path: ""
+  - name: published
+    id: pBl9dt
+    type: Date
+    options: {}
+    path: ""
+  - name: next interval
+    id: nXi3vq
+    type: CycleDuration
+    options:
+      presets:
+        - P90D
+        - P180D
+        - P360D
+    path: ""
+  - name: review
+    id: rV7kdp
+    type: Date
+    options:
+      nextIntervalField: next interval
+    path: ""
+  - name: themes
+    id: tH3mes
+    type: Multi
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "1": Ecology
+        "2": Politics
+        "3": Religion
+    path: ""
+  - name: awards
+    id: aW4rds
+    type: MultiInput
+    options: {}
+    path: ""
+---

--- a/demo/012_link_a_note/demo-vault/Dune.md
+++ b/demo/012_link_a_note/demo-vault/Dune.md
@@ -1,0 +1,20 @@
+---
+fileClass: Book
+publisher: Chilton Books
+pages: 412
+genre: Science fiction
+read: true
+ownership: Owned
+published: 1965-08-01
+themes:
+  - Ecology
+  - Religion
+awards:
+  - Hugo 1966
+  - Nebula 1965
+---
+Frank Herbert spent five years on desert ecology and the politics of water
+before Chilton Books — until then a publisher of car repair manuals — took the
+manuscript, in 1965.
+
+412 pages in that first edition, and not one of them wasted.

--- a/demo/012_link_a_note/demo-vault/Frank Herbert.md
+++ b/demo/012_link_a_note/demo-vault/Frank Herbert.md
@@ -1,0 +1,7 @@
+---
+fileClass: Author
+born: 1920-10-08
+nationality: American
+---
+Five years of desert ecology before Dune, and a career of asking what a
+messiah costs the people who follow one.

--- a/demo/012_link_a_note/demo-vault/Hergé.md
+++ b/demo/012_link_a_note/demo-vault/Hergé.md
@@ -1,0 +1,7 @@
+---
+fileClass: Author
+born: 1907-05-22
+nationality: Belgian
+---
+Georges Remi, signing his initials backwards. Tintin in Tibet is the one he
+called his own favourite.

--- a/demo/012_link_a_note/demo-vault/J.R.R. Tolkien.md
+++ b/demo/012_link_a_note/demo-vault/J.R.R. Tolkien.md
@@ -1,0 +1,6 @@
+---
+fileClass: Author
+born: 1892-01-03
+nationality: British
+---
+A philologist who invented the languages first and let the stories follow.

--- a/demo/012_link_a_note/demo-vault/Kind of Blue.md
+++ b/demo/012_link_a_note/demo-vault/Kind of Blue.md
@@ -1,0 +1,8 @@
+---
+fileClass: Album
+length: PT45M44S
+---
+Recorded in two sessions at Columbia's 30th Street Studio, March and April 1959,
+with Bill Evans at the piano on every track but one.
+
+Forty-five minutes and forty-four seconds that changed what a quintet could be.

--- a/demo/012_link_a_note/demo-vault/Miles Davis.md
+++ b/demo/012_link_a_note/demo-vault/Miles Davis.md
@@ -1,0 +1,7 @@
+---
+fileClass: Author
+born: 1926-05-26
+nationality: American
+---
+Played the notes he left out. Kind of Blue was recorded in two sessions, mostly
+first takes.

--- a/demo/012_link_a_note/demo-vault/Reading group.md
+++ b/demo/012_link_a_note/demo-vault/Reading group.md
@@ -1,0 +1,9 @@
+---
+fileClass: Activity
+starts: 2026-09-10T19:00
+doors: "18:30"
+---
+The reading group meets at the library on the second Thursday of the month.
+Next session: 10 September 2026, 7 pm — doors at 6:30.
+
+Dune this time; bring the Fremen chapters.

--- a/demo/012_link_a_note/demo-vault/The Lord of the Rings.md
+++ b/demo/012_link_a_note/demo-vault/The Lord of the Rings.md
@@ -1,0 +1,11 @@
+---
+fileClass: Book
+publisher: ""
+pages: ""
+genre: Fantasy
+read: false
+---
+Allen & Unwin brought it out in three volumes from 1954, against Tolkien's wish
+for a single book. Mine is the 1991 paperback set, spines long gone.
+
+1178 pages across the three, appendices included.

--- a/demo/012_link_a_note/demo-vault/Tintin in Tibet.md
+++ b/demo/012_link_a_note/demo-vault/Tintin in Tibet.md
@@ -1,0 +1,4 @@
+Hergé's own favourite, drawn in the middle of a breakdown, and the only album
+with no villain in it. Casterman, 1960.
+
+62 pages, like every album in the series.

--- a/demo/012_link_a_note/scenario.yaml
+++ b/demo/012_link_a_note/scenario.yaml
@@ -1,0 +1,48 @@
+# Narration for take 012 — see ../SCENARIO.md for the format.
+# Opens arc 3: a field whose value is another note. Starts where 011 ended (Book
+# has themes and awards, Dune carries both) and adds the cast this arc needs: the
+# Author class, four author notes, and Authors.base.
+#
+# Why the base ships in the fixture instead of being created on camera: generating
+# one from a class is take 032's subject. Here it is scenery, like the notes.
+#
+# Two facts the script leans on, both read from the source:
+#  - resolveCandidates() has exactly two sources — a base view, or ALL notes as a
+#    fallback. There is no "notes of class X" filter without a base, which is why
+#    steps 3-4 show the unusable list before the fix rather than after it.
+#  - the candidates come back in the view's display order (sort, then group flow),
+#    so Authors.base sorts by `born`: the picker reads Tolkien, Hergé, Herbert,
+#    Davis — visibly not alphabetical. Step 7 is a demonstration, not a claim.
+title: "Fileclass — Link a note to another note"
+description: "A field whose value is a note, with a candidate list you decide."
+doc: "fields/#link-fields-file--media" # deep link used in the description
+tags: "file field, links, bases, candidates"
+vault_name: "Demo"
+plugin: true
+settings:
+  classFilesPath: "Classes/"
+  fileClassAlias: "fileClass"
+initial_pause: 1500
+default_pause: 900
+
+steps:
+  - title: "Dune names its author in the prose, not in a field"
+    pause: 1600
+  - title: "Add a field named author, type File"
+    pause: 1400
+  - title: "Insert it in Dune, open it, and every note is offered"
+    pause: 1800
+  - title: "Even Dune itself — a link field needs a shortlist"
+    pause: 1800
+  - title: "Its options take a base file and one of its views"
+    pause: 1600
+  - title: "Point it at Authors, view All authors"
+    pause: 1400
+  - title: "Four authors now, in the view's order — oldest first, not alphabetical"
+    pause: 1900
+  - title: "Pick Frank Herbert"
+    pause: 1200
+  - title: "Stored as a wikilink, following your own link settings"
+    pause: 1800
+  - title: "A field that points at a note, with a list you decide 🎉"
+    pause: 2200

--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -61,7 +61,7 @@ thread, and a tight smoke test of that type's input path.
 
 | # | Take | Feature | Vault gains | Status |
 | - | ---- | ------- | ----------- | ------ |
-| 012 | Link a note to another note | `File` (candidates from a base) | `Author` class + notes | |
+| 012 | Link a note to another note | `File` (candidates from a base) | `Author` class + notes, `Authors.base` | ✅ [published](https://www.youtube.com/watch?v=orwUfnJCWT4) |
 | 013 | Translators, illustrators, several links | `MultiFile` | `Comic.contributors` | |
 | 014 | Covers and attachments | `Media`, `MultiMedia` | `Book.cover` | |
 | 015 | Candidates that depend on another field | conditional candidates | `Comic.series` | |

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -130,6 +130,8 @@ when several values share one shape — e.g. a list of repository URLs from a
 
 ## Link fields (File / Media)
 
+{{< video "012" >}}
+
 `File`, `MultiFile`, `Media`, and `MultiMedia` store wikilinks. Their **candidate
 list comes from a Base view** — configure the field with a `.base` file and view
 (`baseFile` + `viewName`); this replaces Metadata Menu's Dataview query and Media

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -56,3 +56,7 @@ other. Captions are English; YouTube translates them into your language.
 ## Several values in one field
 
 {{< video "011" >}}
+
+## Link a note to another note
+
+{{< video "012" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -130,5 +130,16 @@
     "durationSeconds": 114,
     "recordedWith": "0.1.1",
     "privacyStatus": "public"
+  },
+  "012": {
+    "id": "orwUfnJCWT4",
+    "url": "https://www.youtube.com/watch?v=orwUfnJCWT4",
+    "title": "Fileclass #012 · Link a note to another note",
+    "subject": "Link a note to another note",
+    "scenario": "012_link_a_note",
+    "doc": "fields/#link-fields-file--media",
+    "durationSeconds": 95,
+    "recordedWith": "0.1.1",
+    "privacyStatus": "public"
   }
 }


### PR DESCRIPTION
Opens **arc 3** — [watch](https://www.youtube.com/watch?v=orwUfnJCWT4). The fixture gains the `Author` class, four author notes and `Authors.base`; the take creates `Book.author` as a `File` field and narrows its candidates to that base's view.

Two things the script leans on, both **verified in the real picker** rather than assumed:

**There is exactly one fallback, and it is unusable.** With no base configured, the candidate list is every note in the vault — class notes and Dune itself included. `resolveCandidates()` has no "notes of class X" filter, so this isn't a shortcut in the script: it is the only thing that can happen. That's why steps 3-4 show the mess *before* the fix rather than after it.

**The picker follows the view's order**, so `Authors.base` sorts by `born` and step 7 demonstrates instead of claiming:

```
no base : Tintin, LOTR, Reading group, Miles Davis, Kind of Blue, …,
          Dune, Book, Author, Album, Activity, Atomic Habits
base    : J.R.R. Tolkien, Hergé, Frank Herbert, Miles Davis    (1892, 1907, 1920, 1926)
```

Alphabetically that list would read Frank Herbert, Hergé, J.R.R. Tolkien, Miles Davis — so the order on screen is visibly the view's own.

The base **ships in the fixture** rather than being generated on camera: *Create a base for a class* is take 032's subject, and here the base is scenery like the notes.

Docs: `{{< video "012" >}}` placed in the *Link fields (File / Media)* section, and the roadmap row notes the fixture also gains `Authors.base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)