### PR TITLE
docs: Tour #1 is published, and it opens the documentation

### DIFF
--- a/demo/ROADMAP.md
+++ b/demo/ROADMAP.md
@@ -23,7 +23,7 @@ One take before the arcs, and the only one that shows the whole plugin end to en
 
 | # | Take | Feature | Vault gains | Status |
 | - | ---- | ------- | ----------- | ------ |
-| 000 | Tour #1 — from an untyped vault to a typed library | install, class folder, a class bound by folder, `File` candidates narrowed by another field | untyped library + `Authors/` + `Authors.base` | scripted |
+| 000 | Tour #1 — from an untyped vault to a typed library | install, class folder, a class bound by folder, `File` candidates narrowed by another field | untyped library + `Authors/` + `Authors.base` | ✅ [published](https://www.youtube.com/watch?v=rScC86I2vlg) |
 
 It is deliberately the exception to the 60-second rule (~5 min), and it can only be
 recorded once the store carries the release with #19 — the install happens on camera.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -27,6 +27,15 @@ It is the successor of [Metadata Menu](https://github.com/mdelobelle/metadatamen
 (same author). Metadata Menu goes into maintenance mode; if you rely on Dataview
 inline fields (`key:: value`), stay there.
 
+## See it work
+
+Five minutes, from a vault where every note types its own properties by hand to a
+library with two classes, guided input, and a candidate list that narrows itself.
+
+{{< video-embed "000" >}}
+
+Then one short video per feature, on the [Videos](videos/) page.
+
 ## Documentation
 
 - [Positioning](positioning/) — how Fileclass relates to core Properties, core

--- a/docs/content/videos.md
+++ b/docs/content/videos.md
@@ -9,6 +9,10 @@ weight: 15
 One feature per video, a minute or two each, in the order they build on each
 other. Captions are English; YouTube translates them into your language.
 
+## Tour #1: from an untyped vault to a typed library
+
+{{< video "000" >}}
+
 ## Install and set up
 
 {{< video "001" >}}

--- a/docs/data/videos.json
+++ b/docs/data/videos.json
@@ -1,4 +1,15 @@
 {
+  "000": {
+    "id": "rScC86I2vlg",
+    "url": "https://www.youtube.com/watch?v=rScC86I2vlg",
+    "title": "Fileclass #000 · Tour #1: from an untyped vault to a typed library",
+    "subject": "Tour #1: from an untyped vault to a typed library",
+    "scenario": "000_tour_first_look",
+    "doc": "",
+    "durationSeconds": 308,
+    "recordedWith": null,
+    "privacyStatus": "public"
+  },
   "001": {
     "id": "KKG_36JGjWA",
     "url": "https://www.youtube.com/watch?v=KKG_36JGjWA",


### PR DESCRIPTION
Take 000 — **Tour #1: from an untyped vault to a typed library** (5:08) — is public: https://www.youtube.com/watch?v=rScC86I2vlg

- `publish.mjs` added it to `docs/data/videos.json` and to the top of the [Videos](https://mdelobelle.github.io/fileclass/videos/) page, and marked it done in the demo roadmap;
- the documentation home page now **plays it** under *See it work*. A reader landing there gets three paragraphs about typed properties and no sense of what the plugin feels like to use; the tour answers that end to end, install included. `video-embed` rather than `video` because a page with a single video can afford the iframe — which is the trade-off those two shortcodes exist for.

Seventeen videos now, 36 minutes total, all public. Hugo isn't installed here, so the docs build is verified by `docs.yml` on this PR rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)