### PR TITLE
chore: drop the "good first issue" label

### DIFF
--- a/.claude/docs/TRIAGE.md
+++ b/.claude/docs/TRIAGE.md
@@ -56,7 +56,7 @@ The form renders as a Markdown body with `### <label>` headings — parse those.
 ## Suggested labels
 
 `bug` / `enhancement` (auto-applied by the form) · `needs-info` ·
-`needs-repro` · `duplicate` · `out-of-scope` · `good first issue` ·
+`needs-repro` · `duplicate` · `out-of-scope` ·
 plus an area label matching the table above.
 
 ## Output shape (triage comment)

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,9 +28,9 @@
 - name: out-of-scope
   color: "e99695"
   description: "Belongs to Bases (Lookup/Formula/queries) or is not Fileclass's job"
-- name: good first issue # exact name → GitHub's contributor-discovery features
-  color: "7057ff"
-  description: Good for newcomers
+# Deliberately absent: "good first issue". Aggregators republish it, and the
+# contributors it attracts cost more to review than handling the issue here
+# would. Removed from the repo too, so re-adding it means re-adding it here.
 - name: wontfix
   color: "ffffff"
   description: Deliberately not being worked on


### PR DESCRIPTION
The label is republished by aggregators, and the contributors it draws cost more to review than handling the issue would. Removed from the repo (only #71 and #72 carried it, both closed) — and from `.github/labels.yml`, without which the sync workflow would recreate it on its next run. The entry is replaced by a comment stating why it is absent, so the reasoning sits where someone would go to re-add it. `TRIAGE.md` no longer suggests it either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)