### PR TITLE
ci: one release per tag, with the changelog as its notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,26 @@ jobs:
             main.js
             styles.css
 
+      # The notes are the CHANGELOG's own section for this version — the text written while
+      # the work happened, rather than a list of commit subjects. It also means there is
+      # exactly **one** release per tag: this job used to run beside a `gh release create`
+      # done by hand, so every version ended up with two drafts, and the one deleted was
+      # usually this one — the only one whose assets are built here and attested.
+      - name: Notes for this version, from the changelog
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          awk -v tag="$tag" '
+            $0 ~ "^## \\[" tag "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error file=CHANGELOG.md::no '## [$tag]' section — the release notes would be empty"
+            exit 1
+          fi
+          echo "--- notes for $tag ---"
+          head -20 release-notes.md
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +69,6 @@ jobs:
           # Obsidian only downloads main.js/manifest.json/styles.css — no extras.
           gh release create "$tag" \
             --title="$tag" \
-            --generate-notes \
+            --notes-file release-notes.md \
             --draft \
             main.js manifest.json styles.css


### PR DESCRIPTION
Cleaning up two duplicate drafts turned up their cause, which is structural rather than accidental.

`release.yml` fires on tag push and runs `gh release create --draft --generate-notes`. I then ran `gh release create` by hand right after, with better notes. **Two drafts per version**, every time — that is where the 0.2.12 and 0.2.13 duplicates came from.

And the one that usually got deleted was the workflow's — the wrong one to lose. Its assets are built in CI from the tagged source and carry a **provenance attestation** (`actions/attest-build-provenance`, added on the Obsidian review's recommendation); mine were built on my laptop and uploaded.

So the workflow keeps the job and gains the only thing that made me do it by hand: the notes come from the **CHANGELOG's own section** for that tag — the text written while the work happened, not a list of commit subjects. If no `## [x.y.z]` section exists, the job fails with a message instead of publishing an empty release.

```
awk -v tag="$tag" '
  $0 ~ "^## \\[" tag "\\]" { found = 1; next }
  found && /^## \[/ { exit }
  found { print }
' CHANGELOG.md > release-notes.md
```

Tried against the current changelog for `0.2.13`: 39 lines, starting at `### Changed` and stopping before `## [0.2.12]`.

From here the release flow is: merge the release PR, push the signed tag, and the draft is waiting — right assets, right words, nothing to do by hand.

**One thing to decide about 0.2.13**, which I cannot decide for you: the draft that survives is *mine*, so its `main.js` was built on my machine and has no attestation. Either publish it as it stands, or delete it and re-push the tag so the workflow rebuilds and attests — I can do the second in a minute, and the notes will then come from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)