### PR TITLE
docs(architecture): field order is the class's, on every surface

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -415,6 +415,16 @@ canvas file tracking (comes with the planned Canvas engine, §9.1).
   view: editable cells, validation columns, and the *Manage `<FileClass>`* wrench,
   each scoped to its own embed. See §3.1 for the two rules an embed enforces that a
   leaf does not (fill the container, expose `type`).
+- **Field order is the class's, on every surface.** The note-fields modal, the
+  Properties row order after a reorder, and a managed view's columns all show the fields
+  in the order the class declares them — one contract, so a reader who learns it once
+  knows what any surface will do. Stated by the author (13 August 2026) when confirming
+  `mergeOrder`: *"ça me va bien que la vue corresponde à l'ordre des colonnes de la
+  classe, tout comme le note fields modal. c'est un contrat universel."*
+  What is **not** ours: `formula.*` and `file.*` columns, which a reader adds for reading
+  rather than for editing. Those keep their positions through a sync; only the field slots
+  are refilled. Do not "improve" this into preserving a hand-picked field order — it was
+  weighed and declined.
 - **The class ↔ view link** (`baseFile`/`baseView` on the class note) is what names
   the table: `Books.base › Book` is Book's view even when a row carries several
   classes. It is also a uniqueness constraint — two classes mirroring into one view

--- a/src/views/baseYaml.ts
+++ b/src/views/baseYaml.ts
@@ -183,7 +183,9 @@ export function keptColumns(order: readonly unknown[]): string[] {
  *
  * **Positions are the reader's, the field sequence is the class's.** Every `file.*` and `formula.*`
  * column stays in the slot it occupies; the remaining slots are filled with the class's fields, in
- * the class's order. So a `formula.Room` sitting third stays third, and a `file.mtime` between two
+ * the class's order — the same contract the note-fields modal keeps, so one rule covers every surface
+ * (§11). Those two families are additions made for *reading*, not for editing, which is why they are
+ * left alone and the fields are not. So a `formula.Room` sitting third stays third, and a `file.mtime` between two
  * fields stays between two fields — which the previous version got wrong by rebuilding the order as
  * "name, fields, then the rest", moving columns nobody asked to move.
  *


### PR DESCRIPTION
The contract behind `mergeOrder`, in your own words when you confirmed it:

> ça me va bien que la vue corresponde à l'ordre des colonnes de la classe, tout comme le note fields modal. c'est un contrat universel. les formula.* et file.* sont juste des ajouts que l'utilisateur fait pour des questions de visualisation, pas pour de la manipulation

Written into ARCHITECTURE §11 and onto the function itself, with the alternative — preserving a hand-picked field order, a sync only adding and removing — recorded as weighed and declined. That is the kind of decision that gets re-litigated by whoever reads the code next, including me in six months.

Comment-only: the bundle is byte-identical, so nothing ships differently.

**Why this is a separate PR**: I committed it onto #172's branch after that PR was merged — the same mistake I made after #155 was merged, and one I had said I would stop making by checking a PR's state before committing on its branch. The fix itself did land; only this note was orphaned, and it is replayed here unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)