### PR TITLE
chore(demo): stage demo vaults in dark mode

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -38,7 +38,7 @@ node record.mjs 001        # from demo/ — or `node demo/record.mjs 001` from t
 1. It asks to quit your Obsidian, then stages
    `~/fileclass-demos/<scenario>/<vault>` from the scenario's `demo-vault/`
    fixture — installing the freshly built plugin when the scenario starts with it,
-   and always in **light mode with the Minimal theme** whatever your system uses.
+   and always in **dark mode with the Minimal theme** whatever your system uses.
 2. It relaunches Obsidian on that vault with `--remote-debugging-port=9222`, then
    waits for the cue: start QuickTime (File → New Screen Recording), size the
    window, and press **⌘⌃⌥⇧C** when you're rolling. Nothing is on a timer, so the

--- a/demo/SCENARIO.md
+++ b/demo/SCENARIO.md
@@ -267,9 +267,9 @@ digit. Versions and dates are left alone.
   `record.mjs` installs the freshly built plugin at staging time. A stale plugin
   copy in git is a wrong demo waiting to happen.
 - `.obsidian/appearance.json`, `core-plugins.json`, `app.json` are written with
-  video-friendly defaults unless the fixture ships its own: **light mode
-  (`moonstone`) + the Minimal theme**, 18px base font, Bases enabled. Every take
-  records light whatever the operator's system appearance is; the theme is copied
+  video-friendly defaults unless the fixture ships its own: **dark mode
+  (`obsidian`) + the Minimal theme**, 18px base font, Bases enabled. Every take
+  records dark whatever the operator's system appearance is; the theme is copied
   from `~/Obsidian-Dev/.obsidian/themes/Minimal` (or `$FILECLASS_DEMO_THEME`), so
   no third-party CSS is committed here. Only override it in a fixture if the
   feature being shown *is* about appearance.

--- a/demo/frontmatter-schema-probe.mjs
+++ b/demo/frontmatter-schema-probe.mjs
@@ -13,7 +13,7 @@ export default async function ({ page, sleep }) {
 	await sleep(3000);
 	const openSource = () => page.evaluate(async () => {
 		const app = window.app;
-		app.changeTheme?.("moonstone"); app.customCss?.setTheme?.("Minimal");
+		app.changeTheme?.("obsidian"); app.customCss?.setTheme?.("Minimal");
 		const leaf = app.workspace.getLeaf(false);
 		await leaf.openFile(app.vault.getAbstractFileByPath("Dune.md"));
 		await leaf.setViewState({ type: "markdown", state: { file: "Dune.md", mode: "source", source: true } });

--- a/demo/lib/stage.mjs
+++ b/demo/lib/stage.mjs
@@ -73,12 +73,12 @@ const DEFAULTS = {
 		"file-recovery": true,
 		bases: true,
 	},
-	// Demos always record in LIGHT mode with the Minimal theme, whatever the
-	// operator's system appearance is: `moonstone` = light, `obsidian` = dark.
+	// Demos always record in DARK mode with the Minimal theme, whatever the
+	// operator's system appearance is: `obsidian` = dark, `moonstone` = light.
 	// Bigger base font so the UI reads on video.
 	"appearance.json": {
 		baseFontSize: 18,
-		theme: "moonstone",
+		theme: "obsidian",
 		cssTheme: THEME,
 		nativeMenus: false,
 	},

--- a/demo/multiclass-relation-probe.mjs
+++ b/demo/multiclass-relation-probe.mjs
@@ -13,7 +13,7 @@ export default async function ({ page, sleep }) {
 	await sleep(3000);
 	note("setup", await page.evaluate(async () => {
 		const app = window.app;
-		app.changeTheme?.("moonstone"); app.customCss?.setTheme?.("Minimal");
+		app.changeTheme?.("obsidian"); app.customCss?.setTheme?.("Minimal");
 		// A view about two classes, declared as Book.author read backwards.
 		const base = app.vault.getAbstractFileByPath("Books.base");
 		const yaml = await app.vault.read(base);

--- a/demo/multimedia-gallery-probe.mjs
+++ b/demo/multimedia-gallery-probe.mjs
@@ -14,7 +14,7 @@ export default async function ({ page, sleep }) {
 	await sleep(3000);
 	note("setup", await page.evaluate(async () => {
 		const app = window.app;
-		app.changeTheme?.("moonstone"); app.customCss?.setTheme?.("Minimal");
+		app.changeTheme?.("obsidian"); app.customCss?.setTheme?.("Minimal");
 		// Give Book a MultiMedia field, bound to the same candidates as `cover`.
 		const file = app.vault.getAbstractFileByPath("Classes/Book.md");
 		await app.fileManager.processFrontMatter(file, (fm) => {

--- a/demo/related-views-options-probe.mjs
+++ b/demo/related-views-options-probe.mjs
@@ -13,7 +13,7 @@ export default async function ({ page, sleep }) {
 	await sleep(3000);
 	note("open options", await page.evaluate(async () => {
 		const app = window.app;
-		app.changeTheme?.("moonstone"); app.customCss?.setTheme?.("Minimal");
+		app.changeTheme?.("obsidian"); app.customCss?.setTheme?.("Minimal");
 		const leaf = app.workspace.getLeaf(false);
 		await leaf.openFile(app.vault.getAbstractFileByPath("Classes/Book.md"));
 		await new Promise((r) => setTimeout(r, 2500));

--- a/demo/two-related-views-probe.mjs
+++ b/demo/two-related-views-probe.mjs
@@ -15,7 +15,7 @@ export default async function ({ page, sleep }) {
 	await sleep(3000);
 	note("setup", await page.evaluate(async () => {
 		const app = window.app;
-		app.changeTheme?.("moonstone"); app.customCss?.setTheme?.("Minimal");
+		app.changeTheme?.("obsidian"); app.customCss?.setTheme?.("Minimal");
 		// Two views over Book.author read backwards: one for read books, one for unread.
 		const base = app.vault.getAbstractFileByPath("Books.base");
 		const yaml = await app.vault.read(base);


### PR DESCRIPTION
> tu peux mettre les vaults de demo en dark mode par défaut stp ?

Every staged vault came up in **light** mode (`moonstone`) with Minimal, whatever the operator's system appearance was. It now comes up **dark** (`obsidian`) — same theme, same 18px base font, same "independent of the operator's system" rule.

- `demo/lib/stage.mjs` — the appearance written into every staged vault.
- The five probes that force the theme at runtime before a screenshot, so a measurement still looks like a recording.
- `demo/SCENARIO.md` and `demo/README.md`, which both stated the light rule.

Measured on a staged vault: `theme-dark` on the body, `cssTheme: Minimal`, `baseFontSize: 18`.

**The 46 published takes were recorded in light**, and that is not a reason to re-record any of them — the note is in the commit message so nobody "fixes" them later on that ground alone.